### PR TITLE
Add release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,28 @@
+categories:
+  - title: '🚀 Enhancements'
+    label: 'enhancement'
+  - title: '🐛 Bug Fixes'
+    label: 'bug'
+  - title: '📜 Scalafix Migrations'
+    label: 'scalafix-migration'
+  - title: '📗 Documentation'
+    label: 'documentation'
+  - title: '🧪 Test Improvements'
+    label: 'testing'
+  - title: '🏗️ Build Improvements'
+    label: 'build'
+  - title: '🔧 Refactorings'
+    label: 'refactoring'
+  - title: '🌱 Dependency Updates'
+    label: 'dependency-update'
+exclude-labels:
+  - 'administration'
+  - 'repos-update'
+template: |
+  ## What's changed
+
+  $CHANGES
+
+  ## Contributors to this release
+
+  $CONTRIBUTORS

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,15 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Bit of a question as to whether you would want to add this one. I personally like it, as it kind of automatically curates the PRs that are yet to be released, in a draft release.

Copied from:
* https://github.com/Slakah/uritemplate4s/pull/223
* https://github.com/scala-steward-org/scala-steward/commit/d8e1fd39007fefdb251ec0f07887964cd75a0962


You end up with something which looks like this https://github.com/scala-steward-org/scala-steward/releases/tag/v0.7.0 .
