### PR TITLE
Optimize string parsing in our benchmark.

### DIFF
--- a/bench/src/main/scala/cats/parse/bench/self.scala
+++ b/bench/src/main/scala/cats/parse/bench/self.scala
@@ -40,7 +40,9 @@ object Json {
     val recurse = P.defer1(parser)
     val pnull = P.string1("null").as(JNull)
     val bool = P.string1("true").as(JBool.True).orElse1(P.string1("false").as(JBool.False))
-    val justStr = JsonStringUtil.simpleString.orElse1(JsonStringUtil.escapedString('"'))
+    val justStr = JsonStringUtil.simpleString
+      .backtrack
+      .orElse1(JsonStringUtil.escapedString('"'))
     val str = justStr.map(JString(_))
     val num = JsonNumber.parser.map(JNum(_))
 


### PR DESCRIPTION
This adds an optimistic optimization: it tries to parse a non-escaped string
first. If the string doesn't have any escapes, it can use substring to directly
allocate the value to be returned. If not, the simple parser bails and we have
to use the slower parser that can handle any string value.

Jawn uses a similar optimization for string parsing.

With this in place, I get the following benchmark results:

    Benchmark                    Mode  Cnt   Score    Error  Units
    Bla25Bench.catsParseParse    avgt    3  60.406  20.161  ms/op
    Bla25Bench.fastparseParse    avgt    3  29.704   1.940  ms/op
    Bla25Bench.jawnParse         avgt    3  12.774   3.355  ms/op
    Bla25Bench.parboiled2Parse   avgt    3  38.723   6.237  ms/op
    Bla25Bench.parsleyParseCold  avgt    3  68.060   3.029  ms/op
    Total time: 306 s (05:06), completed Nov 1, 2020 11:44:52 PM

I only used -i 3 and -wi 3 but this still shows an improvement (previously I
was seeing more like 100+ ms for cats-parse).