### PR TITLE
Upgrading sbt-github-actions to 0.9.4 to remove deprecations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Java and Scala
-        uses: olafurpg/setup-scala@v5
+        uses: olafurpg/setup-scala@v10
         with:
           java-version: ${{ matrix.java }}
 
@@ -110,7 +110,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Java and Scala
-        uses: olafurpg/setup-scala@v5
+        uses: olafurpg/setup-scala@v10
         with:
           java-version: ${{ matrix.java }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ project/plugins/project/
 # Scala-IDE specific
 .scala_dependencies
 .worksheet
+.vscode
 
 # Sublime
 *.sublime-project

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,7 +7,7 @@ addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.3.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.0")
 addSbtPlugin("com.codecommit" % "sbt-spiewak-sonatype" % "0.16.0")
-addSbtPlugin("com.codecommit" % "sbt-github-actions" % "0.9.3")
+addSbtPlugin("com.codecommit" % "sbt-github-actions" % "0.9.4")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 
 // This is adding this compiler plugin as a dependency for the build, not the code itself


### PR DESCRIPTION
Fixes https://github.com/typelevel/cats-parse/issues/25 to remove the use of deprecated methods in github actions by upgrading to 0.9.4.  