### PR TITLE
Test some distributivity laws

### DIFF
--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -406,6 +406,14 @@ object Parser extends ParserInstances {
 
     def <*[B](that: Parser[B]): Parser[A] =
       softProduct(parser, void(that)).map(_._1)
+
+    /** If we can parse this then that, do so,
+      * if we fail that without consuming, rewind
+      * before this without consuming.
+      * If either consume 1 or more, do not rewind
+      */
+    def with1: Soft01[A] =
+      new Soft01(parser)
   }
 
   /** If we can parse this then that, do so,


### PR DESCRIPTION
I had naively hoped a strong distributive law would hold. This cannot hold for parsers without total backtracking and as such seems like it was perhaps erroneously added to cats Alternative law testing. I added a comment linking to some past difficulties cats had with a related issue and also to a discussion that some Haskell Alternative instances are not distributive.

cc @non