### PR TITLE
Add failWith for user defined error messages

### DIFF
--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -1089,7 +1089,7 @@ object Parser extends ParserInstances {
     final def doesBacktrack(p: Parser[Any]): Boolean =
       p match {
         case Backtrack(_) | Backtrack1(_) | AnyChar | CharIn(_, _, _) | Str(_) | Length(_) |
-            StartParser | EndParser | Index | Pure(_) =>
+            StartParser | EndParser | Index | Pure(_) | Fail() | FailWith(_) =>
           true
         case Map(p, _) => doesBacktrack(p)
         case Map1(p, _) => doesBacktrack(p)


### PR DESCRIPTION
This was an oversight in the originally released code.

The use case is to allow validation by users especially when used with flatMap.