### PR TITLE
Add some ignoreCase methods, rename stringCI to ignoreCase

### DIFF
--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -615,11 +615,18 @@ object Parser extends ParserInstances {
     * or fail. This backtracks on failure
     * this is an error if the string is empty
     */
-  def stringCI1(str: String): Parser1[Unit] =
+  def ignoreCase1(str: String): Parser1[Unit] =
     if (str.length == 1) {
-      val c = str.charAt(0)
-      charIn(c.toLower, c.toUpper).void
+      ignoreCaseChar(str.charAt(0))
     } else Impl.Str(str, true)
+
+  /** Ignore the case of a single character
+    *  If you want to know if it is upper or
+    *  lower, use .string to capture the string
+    *  and then map to process the result.
+    */
+  def ignoreCaseChar(c: Char): Parser1[Unit] =
+    charIn(c.toLower, c.toUpper).void
 
   /** Parse a given string or
     * fail. This backtracks on failure
@@ -639,9 +646,9 @@ object Parser extends ParserInstances {
   /** Parse a potentially empty string, in a case-insensitive manner,
     * or fail. This backtracks on failure
     */
-  def stringCI(str: String): Parser[Unit] =
+  def ignoreCase(str: String): Parser[Unit] =
     if (str.length == 0) unit
-    else stringCI1(str)
+    else ignoreCase1(str)
 
   /** go through the list of parsers trying each
     *  as long as they are epsilon failures (don't advance)
@@ -922,6 +929,18 @@ object Parser extends ParserInstances {
       }
     }
 
+  /** Parse any single character in a set of characters as lower or upper case
+    */
+  def ignoreCaseCharIn(cs: Iterable[Char]): Parser1[Char] = {
+    val letters = cs.flatMap { c => c.toUpper :: c.toLower :: Nil }
+    charIn(letters)
+  }
+
+  /** Parse any single character in a set of characters as lower or upper case
+    */
+  def ignoreCaseCharIn(c0: Char, cs: Char*): Parser1[Char] =
+    ignoreCaseCharIn(c0 +: cs)
+
   @inline
   private[this] def charImpl(c: Char): Parser1[Unit] =
     charIn(c :: Nil).void
@@ -941,7 +960,7 @@ object Parser extends ParserInstances {
   /** parse one of a given set of characters
     */
   def charIn(c0: Char, cs: Char*): Parser1[Char] =
-    charIn(c0 :: cs.toList)
+    charIn(c0 +: cs)
 
   /** parse one character that matches a given function
     */

--- a/core/shared/src/test/scala/cats/parse/ParserTest.scala
+++ b/core/shared/src/test/scala/cats/parse/ParserTest.scala
@@ -457,8 +457,10 @@ class ParserTest extends munit.ScalaCheckSuite {
 
   val fooP = Parser.string1("foo")
   val barP = Parser.string1("bar")
-  val fooCIP = Parser.stringCI1("foo")
-  val cCIP = Parser.stringCI1("a")
+  val fooCIP = Parser.ignoreCase1("foo")
+  val cCIP = Parser.ignoreCase1("a")
+  val cCIP1 = Parser.ignoreCaseChar('a')
+  val abcCI = Parser.ignoreCaseCharIn('a', 'b', 'c')
 
   test("string tests") {
     parseTest(fooP, "foobar", ())
@@ -466,7 +468,17 @@ class ParserTest extends munit.ScalaCheckSuite {
     parseTest(fooCIP, "FoO", ())
     parseTest(cCIP, "A", ())
     parseTest(cCIP, "a", ())
+    parseTest(cCIP1, "A", ())
+    parseTest(cCIP1, "a", ())
     parseFail(fooP, "bar")
+
+    parseTest(abcCI, "a", 'a')
+    parseTest(abcCI, "A", 'A')
+    parseTest(abcCI, "b", 'b')
+    parseTest(abcCI, "B", 'B')
+    parseTest(abcCI, "c", 'c')
+    parseTest(abcCI, "C", 'C')
+    parseFail(abcCI, "D")
 
     parseTest(Parser.oneOf1(fooP :: barP :: Nil), "bar", ())
     parseTest(Parser.oneOf1(fooP :: barP :: Nil), "foo", ())


### PR DESCRIPTION
follow up to #46 

What do you think @stephenjudkins ? I want to publish a new version, but the name just wasn't sitting well with me.

Can you review this and the other new methods I added?

There is one ambiguity: string can be converted to `Iterable[Char]` in scala, so I added `ignoreCaseChar` and `ignoreCaseCharIn` but to save space for the common case, I used ignoreCase to accept a string. A clearer, but more verbose approach would be to do ignoreCaseString, but I feel that's a bit long. That said, ignoring case isn't that common, so maybe that's okay. I don't know. 