### PR TITLE
Improve performance around ignoreCase

### DIFF
--- a/core/shared/src/test/scala/cats/parse/ParserTest.scala
+++ b/core/shared/src/test/scala/cats/parse/ParserTest.scala
@@ -79,6 +79,11 @@ object ParserGen {
       GenT(Parser.string(str))
     }
 
+  val ignoreCase: Gen[GenT[Parser]] =
+    Arbitrary.arbitrary[String].map { str =>
+      GenT(Parser.ignoreCase(str))
+    }
+
   val charIn: Gen[GenT[Parser]] =
     Gen.oneOf(
       Arbitrary.arbitrary[List[Char]].map { cs =>
@@ -99,6 +104,12 @@ object ParserGen {
     Arbitrary.arbitrary[String].map { str =>
       if (str.isEmpty) GenT(Parser.fail: Parser1[Unit])
       else GenT(Parser.string1(str))
+    }
+
+  val ignoreCase1: Gen[GenT[Parser1]] =
+    Arbitrary.arbitrary[String].map { str =>
+      if (str.isEmpty) GenT(Parser.fail: Parser1[Unit])
+      else GenT(Parser.ignoreCase1(str))
     }
 
   val fail: Gen[GenT[Parser]] =
@@ -375,6 +386,7 @@ object ParserGen {
           }))
       ),
       (5, expect0),
+      (1, ignoreCase),
       (5, charIn),
       (1, Gen.oneOf(GenT(Parser.start), GenT(Parser.end), GenT(Parser.index))),
       (1, fail),
@@ -401,6 +413,7 @@ object ParserGen {
 
     Gen.frequency(
       (8, expect1),
+      (2, ignoreCase1),
       (8, charIn1),
       (1, Gen.choose(Char.MinValue, Char.MaxValue).map { c => GenT(Parser.char(c)) }),
       (2, rec.map(void1(_))),


### PR DESCRIPTION
I looked at the code on in the java standard library, and by calling regionMatches with a boolean, we have to do another branch inside that code to go to the non-ignore-case mode.

We already have many subclasses of Parser, so by adding one more we aren't harming the optimizer. So, this PR makes a separate case class for ignoring the case, in this way, users that don't ignore the case don't hit a different code path. String parsing is fairly important to the benchmarks, so this seems to give a few % improvement.

Also, I added ignoreCase to the generators to get better coverage.

benchmarks before:
```
[info] Benchmark                        Mode  Cnt    Score    Error  Units
[info] BarBench.catsParseParse          avgt   10   ≈ 10⁻⁴           ms/op
[info] BarBench.fastparseParse          avgt   10   ≈ 10⁻⁴           ms/op
[info] BarBench.jawnParse               avgt   10   ≈ 10⁻⁴           ms/op
[info] BarBench.parboiled2Parse         avgt   10   ≈ 10⁻⁴           ms/op
[info] BarBench.parsleyParseCold        avgt   10    0.092 ±  0.003  ms/op
[info] Bla25Bench.catsParseParse        avgt   10   37.762 ±  0.333  ms/op
[info] Bla25Bench.fastparseParse        avgt   10   22.128 ±  0.141  ms/op
[info] Bla25Bench.jawnParse             avgt   10    9.892 ±  0.144  ms/op
[info] Bla25Bench.parboiled2Parse       avgt   10   29.334 ±  0.060  ms/op
[info] Bla25Bench.parsleyParseCold      avgt   10   38.636 ±  0.207  ms/op
[info] CountriesBench.catsParseParse    avgt   10   12.554 ±  0.059  ms/op
[info] CountriesBench.fastparseParse    avgt   10    6.705 ±  0.018  ms/op
[info] CountriesBench.jawnParse         avgt   10    1.802 ±  0.007  ms/op
[info] CountriesBench.parboiled2Parse   avgt   10    5.669 ±  0.019  ms/op
[info] CountriesBench.parsleyParseCold  avgt   10   15.657 ±  0.237  ms/op
[info] Qux2Bench.catsParseParse         avgt   10   11.136 ±  0.055  ms/op
[info] Qux2Bench.fastparseParse         avgt   10    9.141 ±  0.013  ms/op
[info] Qux2Bench.jawnParse              avgt   10    2.806 ±  0.008  ms/op
[info] Qux2Bench.parboiled2Parse        avgt   10    8.654 ±  0.026  ms/op
[info] Qux2Bench.parsleyParseCold       avgt   10   14.711 ±  0.064  ms/op
[info] Ugh10kBench.catsParseParse       avgt   10   89.606 ±  0.186  ms/op
[info] Ugh10kBench.fastparseParse       avgt   10   63.336 ±  0.117  ms/op
[info] Ugh10kBench.jawnParse            avgt   10   16.484 ±  0.087  ms/op
[info] Ugh10kBench.parboiled2Parse      avgt   10   52.624 ±  0.069  ms/op
[info] Ugh10kBench.parsleyParseCold     avgt   10  105.521 ±  0.472  ms/op
```

benchmarks after:
```
[info] Benchmark                        Mode  Cnt    Score    Error  Units
[info] BarBench.catsParseParse          avgt   10   ≈ 10⁻⁴           ms/op
[info] BarBench.fastparseParse          avgt   10   ≈ 10⁻⁴           ms/op
[info] BarBench.jawnParse               avgt   10   ≈ 10⁻⁴           ms/op
[info] BarBench.parboiled2Parse         avgt   10   ≈ 10⁻⁴           ms/op
[info] BarBench.parsleyParseCold        avgt   10    0.086 ±  0.001  ms/op
[info] Bla25Bench.catsParseParse        avgt   10   33.627 ±  0.201  ms/op
[info] Bla25Bench.fastparseParse        avgt   10   21.457 ±  0.123  ms/op
[info] Bla25Bench.jawnParse             avgt   10    9.864 ±  0.156  ms/op
[info] Bla25Bench.parboiled2Parse       avgt   10   28.541 ±  0.165  ms/op
[info] Bla25Bench.parsleyParseCold      avgt   10   39.755 ±  0.486  ms/op
[info] CountriesBench.catsParseParse    avgt   10   12.592 ±  0.067  ms/op
[info] CountriesBench.fastparseParse    avgt   10    6.703 ±  0.027  ms/op
[info] CountriesBench.jawnParse         avgt   10    1.744 ±  0.010  ms/op
[info] CountriesBench.parboiled2Parse   avgt   10    5.674 ±  0.030  ms/op
[info] CountriesBench.parsleyParseCold  avgt   10   15.608 ±  0.231  ms/op
[info] Qux2Bench.catsParseParse         avgt   10   11.137 ±  0.039  ms/op
[info] Qux2Bench.fastparseParse         avgt   10    9.243 ±  0.046  ms/op
[info] Qux2Bench.jawnParse              avgt   10    2.790 ±  0.012  ms/op
[info] Qux2Bench.parboiled2Parse        avgt   10    8.393 ±  0.040  ms/op
[info] Qux2Bench.parsleyParseCold       avgt   10   14.662 ±  0.076  ms/op
[info] Ugh10kBench.catsParseParse       avgt   10   87.011 ±  0.613  ms/op
[info] Ugh10kBench.fastparseParse       avgt   10   63.642 ±  0.407  ms/op
[info] Ugh10kBench.jawnParse            avgt   10   17.353 ±  0.127  ms/op
[info] Ugh10kBench.parboiled2Parse      avgt   10   52.651 ±  0.263  ms/op
[info] Ugh10kBench.parsleyParseCold     avgt   10  104.997 ±  0.266  ms/op
```