### PR TITLE
Small optimization around makeError

### DIFF
--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -1802,8 +1802,16 @@ object Parser extends ParserInstances {
 
       override def toString = s"CharIn($min, bitSet = ..., $ranges)"
 
-      def makeError(offset: Int): Chain[Expectation] =
-        Chain.fromSeq(ranges.toList.map { case (s, e) => Expectation.InRange(offset, s, e) })
+      def makeError(offset: Int): Chain[Expectation] = {
+        var result = Chain.empty[Expectation]
+        var aux = ranges.toList
+        while (aux.nonEmpty) {
+          val (s, e) = aux.head
+          result = result :+ Expectation.InRange(offset, s, e)
+          aux = aux.tail
+        }
+        result
+      }
 
       override def parseMut(state: State): Char = {
         val offset = state.offset


### PR DESCRIPTION
before:
```
[info] Benchmark                           Mode  Cnt    Score    Error  Units
[info] BarBench.catsParseParse             avgt    3   ≈ 10⁻³           ms/op
[info] Bla25Bench.catsParseParse           avgt    3   42.306 ±  6.775  ms/op
[info] CountriesBench.catsParseParse       avgt    3   16.722 ±  4.179  ms/op
[info] Qux2Bench.catsParseParse            avgt    3   13.183 ±  1.485  ms/op
[info] Ugh10kBench.catsParseParse          avgt    3  100.625 ± 27.054  ms/op
```

after:
```
[info] Benchmark                           Mode  Cnt   Score    Error  Units
[info] BarBench.catsParseParse             avgt    3  ≈ 10⁻⁴           ms/op
[info] Bla25Bench.catsParseParse           avgt    3  35.326 ±  8.988  ms/op
[info] CountriesBench.catsParseParse       avgt    3  14.109 ±  3.304  ms/op
[info] Qux2Bench.catsParseParse            avgt    3  10.504 ±  2.995  ms/op
[info] Ugh10kBench.catsParseParse          avgt    3  88.645 ± 29.553  ms/op
```
