### PR TITLE
Update to cats-core-2.3.0-M2

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 
 object Dependencies {
-  lazy val cats = Def.setting("org.typelevel" %%% "cats-core" % "2.2.0")
+  lazy val cats = Def.setting("org.typelevel" %%% "cats-core" % "2.3.0-M2")
   lazy val munit = Def.setting("org.scalameta" %%% "munit" % "0.7.18")
   lazy val munitScalacheck = Def.setting("org.scalameta" %%% "munit-scalacheck" % "0.7.18")
   lazy val scalaCheck = Def.setting("org.scalacheck" %%% "scalacheck" % "1.14.3")


### PR DESCRIPTION
The Dotty build is pulling in cats-2.2.0_2.13, and we can't mix _2.13 and _3.0.0-M1 dependencies.  cats-2.3.0-M2 is fully cross-published for Dotty.

