### PR TITLE
Right associate products in unmap

### DIFF
--- a/core/shared/src/test/scala/cats/parse/ParserTest.scala
+++ b/core/shared/src/test/scala/cats/parse/ParserTest.scala
@@ -192,7 +192,8 @@ object ParserGen {
     Gen.oneOf(
       GenT[Parser1, (ga.A, gb.A)](Parser.product10(ga.fa, gb.fa)),
       GenT[Parser1, ga.A](ga.fa <* gb.fa),
-      GenT[Parser1, gb.A](ga.fa *> gb.fa)
+      GenT[Parser1, gb.A](ga.fa *> gb.fa),
+      GenT[Parser1, (ga.A, ga.A)](Parser.product10(ga.fa, ga.fa))
     )
   }
 
@@ -200,8 +201,12 @@ object ParserGen {
     implicit val ca: Cogen[ga.A] = ga.cogen
     implicit val cb: Cogen[gb.A] = gb.cogen
     Gen.oneOf(
+      // left is Parser1
       GenT[Parser1, (ga.A, gb.A)](ga.fa.soft ~ gb.fa),
-      GenT[Parser1, (gb.A, ga.A)](gb.fa.with1.soft ~ ga.fa)
+      // right is Parser1
+      GenT[Parser1, (gb.A, ga.A)](gb.fa.with1.soft ~ ga.fa),
+      // both are parser1
+      GenT[Parser1, (ga.A, ga.A)](ga.fa.soft ~ ga.fa)
     )
   }
 
@@ -441,7 +446,7 @@ object ParserGen {
 
 class ParserTest extends munit.ScalaCheckSuite {
 
-  val tests: Int = if (BitSetUtil.isScalaJs) 50 else 1000
+  val tests: Int = if (BitSetUtil.isScalaJs) 50 else 2000
 
   override def scalaCheckTestParameters =
     super.scalaCheckTestParameters


### PR DESCRIPTION
This idea is that in unmap, we can right associate without any additional cost, so why not.

This means if the first item in a product does not match, we can see that quickly. Since unmap is used by void and string, both very common, this should be a meaningful optimization.

Here are benchmarks of this PR:
```
[info] Benchmark                        Mode  Cnt    Score    Error  Units
[info] BarBench.catsParseParse          avgt    5    0.001 ±  0.001  ms/op
[info] BarBench.fastparseParse          avgt    5   ≈ 10⁻⁴           ms/op
[info] BarBench.jawnParse               avgt    5   ≈ 10⁻⁴           ms/op
[info] BarBench.parboiled2Parse         avgt    5   ≈ 10⁻⁴           ms/op
[info] BarBench.parsleyParseCold        avgt    5    0.154 ±  0.004  ms/op
[info] Bla25Bench.catsParseParse        avgt    5   74.026 ±  3.057  ms/op
[info] Bla25Bench.fastparseParse        avgt    5   40.463 ±  0.902  ms/op
[info] Bla25Bench.jawnParse             avgt    5   15.587 ±  2.083  ms/op
[info] Bla25Bench.parboiled2Parse       avgt    5   56.473 ±  4.402  ms/op
[info] Bla25Bench.parsleyParseCold      avgt    5   95.217 ±  4.747  ms/op
[info] CountriesBench.catsParseParse    avgt    5   25.513 ±  1.547  ms/op
[info] CountriesBench.fastparseParse    avgt    5   13.602 ±  0.282  ms/op
[info] CountriesBench.jawnParse         avgt    5    3.411 ±  0.135  ms/op
[info] CountriesBench.parboiled2Parse   avgt    5   11.239 ±  0.658  ms/op
[info] CountriesBench.parsleyParseCold  avgt    5   34.266 ±  7.549  ms/op
[info] Qux2Bench.catsParseParse         avgt    5   20.933 ±  0.641  ms/op
[info] Qux2Bench.fastparseParse         avgt    5   16.323 ±  0.530  ms/op
[info] Qux2Bench.jawnParse              avgt    5    4.338 ±  0.135  ms/op
[info] Qux2Bench.parboiled2Parse        avgt    5   16.619 ±  0.591  ms/op
[info] Qux2Bench.parsleyParseCold       avgt    5   31.967 ±  1.007  ms/op
[info] Ugh10kBench.catsParseParse       avgt    5  175.986 ±  7.386  ms/op
[info] Ugh10kBench.fastparseParse       avgt    5  119.568 ±  3.107  ms/op
[info] Ugh10kBench.jawnParse            avgt    5   28.205 ±  0.951  ms/op
[info] Ugh10kBench.parboiled2Parse      avgt    5  103.439 ±  3.419  ms/op
[info] Ugh10kBench.parsleyParseCold     avgt    5  225.221 ± 12.828  ms/op
```
main has these values:
```
[info] Benchmark                        Mode  Cnt    Score    Error  Units
[info] BarBench.catsParseParse          avgt    5    0.001 ±  0.001  ms/op
[info] BarBench.fastparseParse          avgt    5   ≈ 10⁻⁴           ms/op
[info] BarBench.jawnParse               avgt    5   ≈ 10⁻⁴           ms/op
[info] BarBench.parboiled2Parse         avgt    5   ≈ 10⁻⁴           ms/op
[info] BarBench.parsleyParseCold        avgt    5    0.153 ±  0.007  ms/op
[info] Bla25Bench.catsParseParse        avgt    5   75.374 ±  2.879  ms/op
[info] Bla25Bench.fastparseParse        avgt    5   40.301 ±  0.703  ms/op
[info] Bla25Bench.jawnParse             avgt    5   15.355 ±  0.868  ms/op
[info] Bla25Bench.parboiled2Parse       avgt    5   54.645 ±  2.325  ms/op
[info] Bla25Bench.parsleyParseCold      avgt    5   90.023 ±  7.740  ms/op
[info] CountriesBench.catsParseParse    avgt    5   24.606 ±  0.353  ms/op
[info] CountriesBench.fastparseParse    avgt    5   13.527 ±  0.611  ms/op
[info] CountriesBench.jawnParse         avgt    5    3.432 ±  0.167  ms/op
[info] CountriesBench.parboiled2Parse   avgt    5   10.969 ±  0.604  ms/op
[info] CountriesBench.parsleyParseCold  avgt    5   31.772 ±  4.249  ms/op
[info] Qux2Bench.catsParseParse         avgt    5   21.952 ±  5.557  ms/op
[info] Qux2Bench.fastparseParse         avgt    5   16.040 ±  0.480  ms/op
[info] Qux2Bench.jawnParse              avgt    5    4.360 ±  0.129  ms/op
[info] Qux2Bench.parboiled2Parse        avgt    5   16.577 ±  0.580  ms/op
[info] Qux2Bench.parsleyParseCold       avgt    5   31.782 ±  0.758  ms/op
[info] Ugh10kBench.catsParseParse       avgt    5  177.636 ± 27.918  ms/op
[info] Ugh10kBench.fastparseParse       avgt    5  118.788 ±  5.454  ms/op
[info] Ugh10kBench.jawnParse            avgt    5   29.002 ±  1.812  ms/op
[info] Ugh10kBench.parboiled2Parse      avgt    5   99.011 ±  7.840  ms/op
[info] Ugh10kBench.parsleyParseCold     avgt    5  239.439 ± 52.790  ms/op
```