### PR TITLE
Fix return type on repAs1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ addCommandAlias("fmtCheck", "; scalafmtCheckAll; scalafmtSbtCheck")
 
 addCommandAlias("prePR", "; githubWorkflowGenerate ; +fmt; bench/compile; +test")
 
-ThisBuild / baseVersion := "0.1"
+ThisBuild / baseVersion := "0.2"
 
 ThisBuild / organization := "org.typelevel"
 ThisBuild / organizationName := "Typelevel"

--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -659,10 +659,10 @@ object Parser extends ParserInstances {
     def repAs[B](implicit acc: Accumulator[A, B]): Parser[B] =
       Parser.repAs(self)(acc)
 
-    def repAs1[B](implicit acc: Accumulator1[A, B]): Parser[B] =
+    def repAs1[B](implicit acc: Accumulator1[A, B]): Parser1[B] =
       Parser.repAs1(self, min = 1)(acc)
 
-    def repAs1[B](min: Int)(implicit acc: Accumulator1[A, B]): Parser[B] =
+    def repAs1[B](min: Int)(implicit acc: Accumulator1[A, B]): Parser1[B] =
       Parser.repAs1(self, min = min)(acc)
   }
 


### PR DESCRIPTION
This was an oversight: the repAs1 extension method hid that it returns a Parser1

The work around is to directly call the repAs1 method on the Parser companion which does return the correct type.
