### PR TITLE
filter, based on selective

### DIFF
--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -1745,8 +1745,7 @@ object Parser extends ParserInstances {
       else null.asInstanceOf[B]
     }
 
-    case class Select[A, B](parser: Parser[Either[A, B]], fn: Parser[A => B])
-        extends Parser[B] {
+    case class Select[A, B](parser: Parser[Either[A, B]], fn: Parser[A => B]) extends Parser[B] {
       override def parseMut(state: State): B = Impl.select[A, B](parser, fn, state)
     }
 

--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -1338,8 +1338,7 @@ object Parser extends ParserInstances {
           // we discard any allocations done by fn
           unmap(p)
         case Select(p, fn) =>
-          // we discard any allocations done by fn
-          Select(p, unmap(fn).map(Function.const))
+          Select(p, unmap(fn).asInstanceOf[Parser[Any => Any]])
         case StringP(s) =>
           // StringP is added privately, and only after unmap
           s
@@ -1742,7 +1741,13 @@ object Parser extends ParserInstances {
       state.capture = cap
       if (state.error eq null)
         either match {
-          case Left(a) => fn.map(_(a)).parseMut(state)
+          case Left(a) =>
+            if (state.capture) {
+              fn.map(_(a)).parseMut(state)
+            } else {
+              fn.parseMut(state)
+              null.asInstanceOf[B]
+            }
           case Right(b) => b
         }
       else null.asInstanceOf[B]

--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -1738,7 +1738,10 @@ object Parser extends ParserInstances {
     ): B = {
       val either = parser.parseMut(state)
       if ((state.error eq null) && state.capture)
-        either.valueOr(a => fn.map(_(a)).parseMut(state))
+        either match {
+          case Left(a) => fn.map(_(a)).parseMut(state)
+          case Right(b) => b
+        }
       else null.asInstanceOf[B]
     }
 

--- a/core/shared/src/test/scala/cats/parse/ParserTest.scala
+++ b/core/shared/src/test/scala/cats/parse/ParserTest.scala
@@ -1561,4 +1561,18 @@ class ParserTest extends munit.ScalaCheckSuite {
     }
   }
 
+  property("p.filter(_ => true) == p") {
+    forAll(ParserGen.gen, Arbitrary.arbitrary[String]) { (genP, str) =>
+      val res0 = genP.fa.filter(_ => true).parse(str)
+      val res1 = genP.fa.parse(str)
+      assertEquals(res0, res1)
+    }
+  }
+
+  property("p.filter(_ => false) fails") {
+    forAll(ParserGen.gen, Arbitrary.arbitrary[String]) { (genP, str) =>
+      val res = genP.fa.filter(_ => false).parse(str)
+      assert(res.isLeft)
+    }
+  }
 }

--- a/core/shared/src/test/scala/cats/parse/ParserTest.scala
+++ b/core/shared/src/test/scala/cats/parse/ParserTest.scala
@@ -1588,6 +1588,22 @@ class ParserTest extends munit.ScalaCheckSuite {
     }
   }
 
+  property("select(pa.map(Left(_)))(pf) == pf.ap(pa)") {
+    forAll(ParserGen.gen, ParserGen.gen) { (genP, genRes) =>
+      val pa = genP.fa
+      val pf = null: Parser[genP.A => genRes.A]
+      assertEquals(Parser.select(pa.map(Left(_)))(pf), pf.ap(pa))
+    }
+  }
+
+  property("select(pa.map(Right(_)))(pf) == pa") {
+    forAll(ParserGen.gen, ParserGen.gen) { (genP, genRes) =>
+      val pa = genRes.fa
+      val pf = null: Parser[genP.A => genRes.A]
+      assertEquals(Parser.select(pa.map(Right(_)))(pf), pa)
+    }
+  }
+
   property("p.filter(_ => true) == p") {
     forAll(ParserGen.gen, Arbitrary.arbitrary[String]) { (genP, str) =>
       val res0 = genP.fa.filter(_ => true).parse(str)


### PR DESCRIPTION
Riffing on the ideas of [Staged Selective Parser Combinators](https://mpickering.github.io/papers/parsley-icfp.pdf).

Use case: in http4s, we need to parse various date headers into a 7-tuple of (weekday, year, month, day, hour, minute, second), and then verify that the date is valid (e.g., no 31st of February).  Currently we have to flatMap it, and when parsing, we _don't_ want to flatMap that shit.

Implemented on `branch`.  We should have the full power of Selective.  The primitive operation could also be `select`, which is the abstract function on cats-selective.

Should be able to make a version that fails with a particular message, swapping that in for "empty".

There may be optimizations to sprinkle throughout the code.  Fusing to `Impl.Map` seems possible, for instance.

I'm super sleepy and just following types.  This might all be nonsense.