### PR TITLE
Add a simple law for select

### DIFF
--- a/core/shared/src/test/scala/cats/parse/ParserTest.scala
+++ b/core/shared/src/test/scala/cats/parse/ParserTest.scala
@@ -1647,4 +1647,28 @@ class ParserTest extends munit.ScalaCheckSuite {
       assert(res.isLeft)
     }
   }
+
+  property("select on pure values works as expected") {
+    forAll { (left: Option[Either[Int, String]], right: Option[Int => String], str: String) =>
+      val pleft = left match {
+        case Some(e) => Parser.pure(e)
+        case None => Parser.fail
+      }
+
+      val pright = right match {
+        case Some(f) => Parser.pure(f)
+        case None => Parser.fail
+      }
+
+      assertEquals(
+        Parser.select(pleft)(pright).parse(str).toOption.map(_._2),
+        left.flatMap {
+          case Left(i) => right.map(_(i))
+          case Right(s) =>
+            // here even if right is None we have a result
+            Some(s)
+        }
+      )
+    }
+  }
 }


### PR DESCRIPTION
This is a law that shows the when first argument of the select is Right, we don't look at the second parser.
