### PR TITLE
Implement FunctorFilter and add some more laws

### DIFF
--- a/core/shared/src/test/scala/cats/parse/ParserTest.scala
+++ b/core/shared/src/test/scala/cats/parse/ParserTest.scala
@@ -1739,18 +1739,40 @@ class ParserTest extends munit.ScalaCheckSuite {
     }
   }
 
-  property("mapOrFail is the same as filter + map") {
+  property("mapFilter is the same as filter + map") {
     forAll { (pa: Parser[Int], fn: Int => Option[String], str: String) =>
-      val left = pa.mapOrFail(fn)
+      val left = pa.mapFilter(fn)
       val right = pa.map(fn).filter(_.isDefined).map(_.get)
 
       assertEquals(left.parse(str), right.parse(str))
     }
   }
 
-  property("mapOrFail is the same as filter + map Parser1") {
+  property("mapFilter is the same as filter + map Parser1") {
     forAll { (pa: Parser1[Int], fn: Int => Option[String], str: String) =>
-      val left = pa.mapOrFail(fn)
+      val left = pa.mapFilter(fn)
+      val right = pa.map(fn).filter(_.isDefined).map(_.get)
+
+      assertEquals(left.parse(str), right.parse(str))
+    }
+  }
+
+  property("collect is the same as filter + map") {
+    forAll { (pa: Parser[Int], fn: Int => Option[String], str: String) =>
+      val left = pa.collect {
+        case i if fn(i).isDefined => fn(i).get
+      }
+      val right = pa.map(fn).filter(_.isDefined).map(_.get)
+
+      assertEquals(left.parse(str), right.parse(str))
+    }
+  }
+
+  property("collect is the same as filter + map Parser1") {
+    forAll { (pa: Parser1[Int], fn: Int => Option[String], str: String) =>
+      val left = pa.collect {
+        case i if fn(i).isDefined => fn(i).get
+      }
       val right = pa.map(fn).filter(_.isDefined).map(_.get)
 
       assertEquals(left.parse(str), right.parse(str))


### PR DESCRIPTION
This does a few things:

1. add an arbitrary for Parser that just maps a totally general one into the right type. This should make those parser internally complex, but have the right type for some simple law writing
2. add a few new laws that are easier to write, or that were overlooked in the past
3. add FunctorFilter methods which are related to filter, but also allows a transformation at the same time, e.g. convert a string to an Int32: usually it is easy to see if a string contains a big integer, but only parsing valid int32 makes a very complex parser and potentially bad error messages (although, using a failWith to explain is probably better here, but that pushes you out of select and into flatMap territory).

what do you think @rossabaker 