### PR TITLE
Make 1 the default: rename Foo1 things to Foo, and the associated Foo to Foo0

### DIFF
--- a/bench/src/main/scala/cats/parse/bench/self.scala
+++ b/bench/src/main/scala/cats/parse/bench/self.scala
@@ -22,7 +22,7 @@
 package cats.parse.bench.self
 
 import cats.implicits._
-import cats.parse.{Parser => P, Parser1 => P1, Numbers}
+import cats.parse.{Parser0 => P, Parser1 => P1, Numbers}
 import org.typelevel.jawn.ast._
 
 /* Based on https://github.com/johnynek/bosatsu/blob/7f4b75356c207b0e0eb2ab7d39f646e04b4004ca/core/src/main/scala/org/bykn/bosatsu/Json.scala */

--- a/bench/src/main/scala/cats/parse/bench/self.scala
+++ b/bench/src/main/scala/cats/parse/bench/self.scala
@@ -46,7 +46,7 @@ object Json {
       P0.char(',').surroundedBy(whitespaces0).void
 
     def rep0[A](pa: P[A]): P0[List[A]] =
-      P0.repSep(pa, min = 0, sep = listSep).surroundedBy(whitespaces0)
+      P0.rep0Sep(pa, min = 0, sep = listSep).surroundedBy(whitespaces0)
 
     val list = rep0(recurse).with1
       .between(P0.char('['), P0.char(']'))

--- a/bench/src/main/scala/cats/parse/bench/self.scala
+++ b/bench/src/main/scala/cats/parse/bench/self.scala
@@ -97,26 +97,26 @@ abstract class GenericStringUtil {
     val escapes = P.charIn(decodeTable.keys.toSeq)
 
     val oct = P.charIn('0' to '7')
-    val octP0 = P.char('o') ~ oct ~ oct
+    val octP = P.char('o') ~ oct ~ oct
 
     val hex = P.charIn(('0' to '9') ++ ('a' to 'f') ++ ('A' to 'F'))
     val hex2 = hex ~ hex
-    val hexP0 = P.char('x') ~ hex2
+    val hexP = P.char('x') ~ hex2
 
     val hex4 = hex2 ~ hex2
     val u4 = P.char('u') ~ hex4
     val hex8 = hex4 ~ hex4
     val u8 = P.char('U') ~ hex8
 
-    val after = P.oneOf[Any](escapes :: octP0 :: hexP0 :: u4 :: u8 :: Nil)
+    val after = P.oneOf[Any](escapes :: octP :: hexP :: u4 :: u8 :: Nil)
     (P.char('\\') ~ after).void
   }
 
   /** String content without the delimiter
     */
-  def undelimitedString1(endP0: P[Unit]): P[String] =
+  def undelimitedString(endP: P[Unit]): P[String] =
     escapedToken.backtrack
-      .orElse((!endP0).with1 ~ P.anyChar)
+      .orElse((!endP).with1 ~ P.anyChar)
       .rep
       .string
       .flatMap { str =>
@@ -132,7 +132,7 @@ abstract class GenericStringUtil {
   def escapedString(q: Char): P[String] = {
     val end: P[Unit] = P.char(q)
     end *> ((simpleString <* end).backtrack
-      .orElse0(undelimitedString1(end) <* end))
+      .orElse0(undelimitedString(end) <* end))
   }
 
   def escape(quoteChar: Char, str: String): String = {

--- a/bench/src/main/scala/cats/parse/bench/self.scala
+++ b/bench/src/main/scala/cats/parse/bench/self.scala
@@ -28,7 +28,7 @@ import org.typelevel.jawn.ast._
 /* Based on https://github.com/johnynek/bosatsu/blob/7f4b75356c207b0e0eb2ab7d39f646e04b4004ca/core/src/main/scala/org/bykn/bosatsu/Json.scala */
 object Json {
   private[this] val whitespace: P[Unit] = P0.charIn(" \t\r\n").void
-  private[this] val whitespaces0: P0[Unit] = whitespace.rep.void
+  private[this] val whitespaces0: P0[Unit] = whitespace.rep0.void
 
   /** This doesn't have to be super fast (but is fairly fast) since we use it in places
     * where speed won't matter: feeding it into a program that will convert it to bosatsu
@@ -45,17 +45,17 @@ object Json {
     val listSep: P[Unit] =
       P0.char(',').surroundedBy(whitespaces0).void
 
-    def rep[A](pa: P[A]): P0[List[A]] =
+    def rep0[A](pa: P[A]): P0[List[A]] =
       P0.repSep(pa, min = 0, sep = listSep).surroundedBy(whitespaces0)
 
-    val list = rep(recurse).with1
+    val list = rep0(recurse).with1
       .between(P0.char('['), P0.char(']'))
       .map { vs => JArray.fromSeq(vs) }
 
     val kv: P[(String, JValue)] =
       justStr ~ (P0.char(':').surroundedBy(whitespaces0) *> recurse)
 
-    val obj = rep(kv).with1
+    val obj = rep0(kv).with1
       .between(P0.char('{'), P0.char('}'))
       .map { vs => JObject.fromSeq(vs) }
 
@@ -117,7 +117,7 @@ abstract class GenericStringUtil {
   def undelimitedString1(endP0: P[Unit]): P[String] =
     escapedToken.backtrack
       .orElse((!endP0).with1 ~ P0.anyChar)
-      .rep1
+      .rep
       .string
       .flatMap { str =>
         unescape(str) match {

--- a/bench/src/main/scala/cats/parse/bench/self.scala
+++ b/bench/src/main/scala/cats/parse/bench/self.scala
@@ -35,9 +35,9 @@ object Json {
     * structured data
     */
   val parser: P[JValue] = {
-    val recurse = P0.defer1(parser)
+    val recurse = P0.defer(parser)
     val pnull = P0.string1("null").as(JNull)
-    val bool = P0.string1("true").as(JBool.True).orElse(P0.string1("false").as(JBool.False))
+    val bool = P0.string1("true").as(JBool.True).orElse(P0.string("false").as(JBool.False))
     val justStr = JsonStringUtil.escapedString('"')
     val str = justStr.map(JString(_))
     val num = Numbers.jsonNumber.map(JNum(_))

--- a/bench/src/main/scala/cats/parse/bench/self.scala
+++ b/bench/src/main/scala/cats/parse/bench/self.scala
@@ -22,48 +22,48 @@
 package cats.parse.bench.self
 
 import cats.implicits._
-import cats.parse.{Parser0 => P, Parser => P1, Numbers}
+import cats.parse.{Parser0 => P0, Parser => P, Numbers}
 import org.typelevel.jawn.ast._
 
 /* Based on https://github.com/johnynek/bosatsu/blob/7f4b75356c207b0e0eb2ab7d39f646e04b4004ca/core/src/main/scala/org/bykn/bosatsu/Json.scala */
 object Json {
-  private[this] val whitespace: P1[Unit] = P.charIn(" \t\r\n").void
-  private[this] val whitespaces0: P[Unit] = whitespace.rep.void
+  private[this] val whitespace: P[Unit] = P0.charIn(" \t\r\n").void
+  private[this] val whitespaces0: P0[Unit] = whitespace.rep.void
 
   /** This doesn't have to be super fast (but is fairly fast) since we use it in places
     * where speed won't matter: feeding it into a program that will convert it to bosatsu
     * structured data
     */
-  val parser: P1[JValue] = {
-    val recurse = P.defer1(parser)
-    val pnull = P.string1("null").as(JNull)
-    val bool = P.string1("true").as(JBool.True).orElse1(P.string1("false").as(JBool.False))
+  val parser: P[JValue] = {
+    val recurse = P0.defer1(parser)
+    val pnull = P0.string1("null").as(JNull)
+    val bool = P0.string1("true").as(JBool.True).orElse(P0.string1("false").as(JBool.False))
     val justStr = JsonStringUtil.escapedString('"')
     val str = justStr.map(JString(_))
     val num = Numbers.jsonNumber.map(JNum(_))
 
-    val listSep: P1[Unit] =
-      P.char(',').surroundedBy(whitespaces0).void
+    val listSep: P[Unit] =
+      P0.char(',').surroundedBy(whitespaces0).void
 
-    def rep[A](pa: P1[A]): P[List[A]] =
-      P.repSep(pa, min = 0, sep = listSep).surroundedBy(whitespaces0)
+    def rep[A](pa: P[A]): P0[List[A]] =
+      P0.repSep(pa, min = 0, sep = listSep).surroundedBy(whitespaces0)
 
     val list = rep(recurse).with1
-      .between(P.char('['), P.char(']'))
+      .between(P0.char('['), P0.char(']'))
       .map { vs => JArray.fromSeq(vs) }
 
-    val kv: P1[(String, JValue)] =
-      justStr ~ (P.char(':').surroundedBy(whitespaces0) *> recurse)
+    val kv: P[(String, JValue)] =
+      justStr ~ (P0.char(':').surroundedBy(whitespaces0) *> recurse)
 
     val obj = rep(kv).with1
-      .between(P.char('{'), P.char('}'))
+      .between(P0.char('{'), P0.char('}'))
       .map { vs => JObject.fromSeq(vs) }
 
-    P.oneOf1(str :: num :: list :: obj :: bool :: pnull :: Nil)
+    P0.oneOf1(str :: num :: list :: obj :: bool :: pnull :: Nil)
   }
 
   // any whitespace followed by json followed by whitespace followed by end
-  val parserFile: P1[JValue] = parser.between(whitespaces0, whitespaces0 ~ P.end)
+  val parserFile: P[JValue] = parser.between(whitespaces0, whitespaces0 ~ P0.end)
 }
 
 object JsonStringUtil extends GenericStringUtil {
@@ -93,46 +93,46 @@ abstract class GenericStringUtil {
       s"\\u$strPad$strHex"
     }.toArray
 
-  val escapedToken: P1[Unit] = {
-    val escapes = P.charIn(decodeTable.keys.toSeq)
+  val escapedToken: P[Unit] = {
+    val escapes = P0.charIn(decodeTable.keys.toSeq)
 
-    val oct = P.charIn('0' to '7')
-    val octP = P.char('o') ~ oct ~ oct
+    val oct = P0.charIn('0' to '7')
+    val octP0 = P0.char('o') ~ oct ~ oct
 
-    val hex = P.charIn(('0' to '9') ++ ('a' to 'f') ++ ('A' to 'F'))
+    val hex = P0.charIn(('0' to '9') ++ ('a' to 'f') ++ ('A' to 'F'))
     val hex2 = hex ~ hex
-    val hexP = P.char('x') ~ hex2
+    val hexP0 = P0.char('x') ~ hex2
 
     val hex4 = hex2 ~ hex2
-    val u4 = P.char('u') ~ hex4
+    val u4 = P0.char('u') ~ hex4
     val hex8 = hex4 ~ hex4
-    val u8 = P.char('U') ~ hex8
+    val u8 = P0.char('U') ~ hex8
 
-    val after = P.oneOf1[Any](escapes :: octP :: hexP :: u4 :: u8 :: Nil)
-    (P.char('\\') ~ after).void
+    val after = P0.oneOf1[Any](escapes :: octP0 :: hexP0 :: u4 :: u8 :: Nil)
+    (P0.char('\\') ~ after).void
   }
 
   /** String content without the delimiter
     */
-  def undelimitedString1(endP: P1[Unit]): P1[String] =
+  def undelimitedString1(endP0: P[Unit]): P[String] =
     escapedToken.backtrack
-      .orElse1((!endP).with1 ~ P.anyChar)
+      .orElse((!endP0).with1 ~ P0.anyChar)
       .rep1
       .string
       .flatMap { str =>
         unescape(str) match {
-          case Right(str1) => P.pure(str1)
-          case Left(_) => P.fail
+          case Right(str1) => P0.pure(str1)
+          case Left(_) => P0.fail
         }
       }
 
-  private val simpleString: P[String] =
-    P.charsWhile(c => c >= ' ' && c != '"' && c != '\\')
+  private val simpleString: P0[String] =
+    P0.charsWhile(c => c >= ' ' && c != '"' && c != '\\')
 
-  def escapedString(q: Char): P1[String] = {
-    val end: P1[Unit] = P.char(q)
+  def escapedString(q: Char): P[String] = {
+    val end: P[Unit] = P0.char(q)
     end *> ((simpleString <* end).backtrack
-      .orElse(undelimitedString1(end) <* end))
+      .orElse0(undelimitedString1(end) <* end))
   }
 
   def escape(quoteChar: Char, str: String): String = {

--- a/bench/src/main/scala/cats/parse/bench/self.scala
+++ b/bench/src/main/scala/cats/parse/bench/self.scala
@@ -59,7 +59,7 @@ object Json {
       .between(P0.char('{'), P0.char('}'))
       .map { vs => JObject.fromSeq(vs) }
 
-    P0.oneOf1(str :: num :: list :: obj :: bool :: pnull :: Nil)
+    P0.oneOf(str :: num :: list :: obj :: bool :: pnull :: Nil)
   }
 
   // any whitespace followed by json followed by whitespace followed by end
@@ -108,7 +108,7 @@ abstract class GenericStringUtil {
     val hex8 = hex4 ~ hex4
     val u8 = P0.char('U') ~ hex8
 
-    val after = P0.oneOf1[Any](escapes :: octP0 :: hexP0 :: u4 :: u8 :: Nil)
+    val after = P0.oneOf[Any](escapes :: octP0 :: hexP0 :: u4 :: u8 :: Nil)
     (P0.char('\\') ~ after).void
   }
 

--- a/bench/src/main/scala/cats/parse/bench/self.scala
+++ b/bench/src/main/scala/cats/parse/bench/self.scala
@@ -22,7 +22,7 @@
 package cats.parse.bench.self
 
 import cats.implicits._
-import cats.parse.{Parser0 => P, Parser1 => P1, Numbers}
+import cats.parse.{Parser0 => P, Parser => P1, Numbers}
 import org.typelevel.jawn.ast._
 
 /* Based on https://github.com/johnynek/bosatsu/blob/7f4b75356c207b0e0eb2ab7d39f646e04b4004ca/core/src/main/scala/org/bykn/bosatsu/Json.scala */

--- a/bench/src/main/scala/cats/parse/bench/self.scala
+++ b/bench/src/main/scala/cats/parse/bench/self.scala
@@ -127,7 +127,7 @@ abstract class GenericStringUtil {
       }
 
   private val simpleString: P0[String] =
-    P0.charsWhile(c => c >= ' ' && c != '"' && c != '\\')
+    P0.charsWhile0(c => c >= ' ' && c != '"' && c != '\\')
 
   def escapedString(q: Char): P[String] = {
     val end: P[Unit] = P0.char(q)

--- a/bench/src/main/scala/cats/parse/bench/self.scala
+++ b/bench/src/main/scala/cats/parse/bench/self.scala
@@ -36,8 +36,8 @@ object Json {
     */
   val parser: P[JValue] = {
     val recurse = P0.defer(parser)
-    val pnull = P0.string1("null").as(JNull)
-    val bool = P0.string1("true").as(JBool.True).orElse(P0.string("false").as(JBool.False))
+    val pnull = P0.string("null").as(JNull)
+    val bool = P0.string("true").as(JBool.True).orElse(P0.string("false").as(JBool.False))
     val justStr = JsonStringUtil.escapedString('"')
     val str = justStr.map(JString(_))
     val num = Numbers.jsonNumber.map(JNum(_))

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ addCommandAlias("fmtCheck", "; scalafmtCheckAll; scalafmtSbtCheck")
 
 addCommandAlias("prePR", "; githubWorkflowGenerate ; +fmt; bench/compile; +test")
 
-ThisBuild / baseVersion := "0.2"
+ThisBuild / baseVersion := "0.3"
 
 ThisBuild / organization := "org.typelevel"
 ThisBuild / organizationName := "Typelevel"

--- a/core/shared/src/main/scala/cats/parse/Accumulator.scala
+++ b/core/shared/src/main/scala/cats/parse/Accumulator.scala
@@ -74,56 +74,56 @@ object Appender {
 }
 
 /** Creates an appender given the first item to be added
-  * This is used to build the result in Parser.repAs1
+  * This is used to build the result in Parser.repAs
   */
-trait Accumulator1[-A, +B] {
+trait Accumulator[-A, +B] {
   def newAppender(first: A): Appender[A, B]
 }
 
 /** Creates an appender
-  * This is used to build the result in Parser.repAs
+  * This is used to build the result in Parser.repAs0
   */
-trait Accumulator[-A, +B] extends Accumulator1[A, B] {
+trait Accumulator0[-A, +B] extends Accumulator[A, B] {
   def newAppender(): Appender[A, B]
   def newAppender(first: A): Appender[A, B] =
     newAppender().append(first)
 }
 
-object Accumulator {
-  implicit val charStringAccumulator: Accumulator[Char, String] =
-    new Accumulator[Char, String] {
+object Accumulator0 {
+  implicit val charStringAccumulator0: Accumulator0[Char, String] =
+    new Accumulator0[Char, String] {
       def newAppender() = Appender.charStringAppender()
     }
 
-  implicit val stringAccumulator: Accumulator[String, String] =
-    new Accumulator[String, String] {
+  implicit val stringAccumulator0: Accumulator0[String, String] =
+    new Accumulator0[String, String] {
       def newAppender() = Appender.stringAppender()
     }
 
-  implicit def listAccumulator[A]: Accumulator[A, List[A]] =
-    new Accumulator[A, List[A]] {
+  implicit def listAccumulator0[A]: Accumulator0[A, List[A]] =
+    new Accumulator0[A, List[A]] {
       def newAppender() = Appender.fromBuilder(List.newBuilder[A])
     }
 
-  implicit def vectorAccumulator[A]: Accumulator[A, Vector[A]] =
-    new Accumulator[A, Vector[A]] {
+  implicit def vectorAccumulator0[A]: Accumulator0[A, Vector[A]] =
+    new Accumulator0[A, Vector[A]] {
       def newAppender() = Appender.fromBuilder(Vector.newBuilder[A])
     }
 
   /** An accumulator that does nothing and returns Unit
-    * Note, this should not generally be used with repAs
+    * Note, this should not generally be used with repAs0
     * because internal allocations still happen. Instead
-    * use .rep.void
+    * use .rep0.void
     */
-  val unitAccumulator: Accumulator[Any, Unit] =
-    new Accumulator[Any, Unit] {
+  val unitAccumulator0: Accumulator0[Any, Unit] =
+    new Accumulator0[Any, Unit] {
       def newAppender() = Appender.unitAppender
     }
 }
 
-object Accumulator1 extends Priority0Accumulator1 {
-  implicit def nonEmptyListAccumulator[A]: Accumulator1[A, NonEmptyList[A]] =
-    new Accumulator1[A, NonEmptyList[A]] {
+object Accumulator extends Priority0Accumulator {
+  implicit def nonEmptyListAccumulator0[A]: Accumulator[A, NonEmptyList[A]] =
+    new Accumulator[A, NonEmptyList[A]] {
       def newAppender(first: A) =
         new Appender[A, NonEmptyList[A]] {
           val bldr = List.newBuilder[A]
@@ -136,8 +136,8 @@ object Accumulator1 extends Priority0Accumulator1 {
         }
     }
 
-  implicit def nonEmptyVectorAccumulator[A]: Accumulator1[A, NonEmptyVector[A]] =
-    new Accumulator1[A, NonEmptyVector[A]] {
+  implicit def nonEmptyVectorAccumulator0[A]: Accumulator[A, NonEmptyVector[A]] =
+    new Accumulator[A, NonEmptyVector[A]] {
       def newAppender(first: A) =
         new Appender[A, NonEmptyVector[A]] {
           val bldr = Vector.newBuilder[A]
@@ -153,6 +153,6 @@ object Accumulator1 extends Priority0Accumulator1 {
     }
 }
 
-private[parse] sealed trait Priority0Accumulator1 {
-  implicit def fromAccumulator[A, B](implicit acc: Accumulator[A, B]): Accumulator1[A, B] = acc
+private[parse] sealed trait Priority0Accumulator {
+  implicit def fromAccumulator0[A, B](implicit acc: Accumulator0[A, B]): Accumulator[A, B] = acc
 }

--- a/core/shared/src/main/scala/cats/parse/Accumulator.scala
+++ b/core/shared/src/main/scala/cats/parse/Accumulator.scala
@@ -74,14 +74,14 @@ object Appender {
 }
 
 /** Creates an appender given the first item to be added
-  * This is used to build the result in Parser1.repAs1
+  * This is used to build the result in Parser.repAs1
   */
 trait Accumulator1[-A, +B] {
   def newAppender(first: A): Appender[A, B]
 }
 
 /** Creates an appender
-  * This is used to build the result in Parser1.repAs
+  * This is used to build the result in Parser.repAs
   */
 trait Accumulator[-A, +B] extends Accumulator1[A, B] {
   def newAppender(): Appender[A, B]

--- a/core/shared/src/main/scala/cats/parse/Numbers.scala
+++ b/core/shared/src/main/scala/cats/parse/Numbers.scala
@@ -26,7 +26,7 @@ object Numbers {
   /** a single base 10 digit
     */
   val digit: Parser[Char] =
-    Parser0.charIn('0' to '9')
+    Parser.charIn('0' to '9')
 
   /** zero or more digit chars
     */
@@ -39,20 +39,20 @@ object Numbers {
   /** a single base 10 digit excluding 0
     */
   val nonZeroDigit: Parser[Char] =
-    Parser0.charIn('1' to '9')
+    Parser.charIn('1' to '9')
 
   /** A String of either 1 '0' or
     * 1 non-zero digit followed by zero or more digits
     */
   val nonNegativeIntString: Parser[String] =
     (nonZeroDigit ~ digits).void
-      .orElse(Parser0.char('0'))
+      .orElse(Parser.char('0'))
       .string
 
   /** A nonNegativeIntString possibly preceded by '-'
     */
   val signedIntString: Parser[String] =
-    (Parser0.char('-').?.with1 ~ nonNegativeIntString).string
+    (Parser.char('-').?.with1 ~ nonNegativeIntString).string
 
   /** map a signedIntString into a BigInt
     */
@@ -75,8 +75,8 @@ object Numbers {
      *     plus = %x2B                ; +
      *     zero = %x30                ; 0
      */
-    val frac: Parser[Any] = Parser0.char('.') ~ digits1
-    val exp: Parser[Unit] = (Parser0.charIn("eE") ~ Parser0.charIn("+-").? ~ digits1).void
+    val frac: Parser[Any] = Parser.char('.') ~ digits1
+    val exp: Parser[Unit] = (Parser.charIn("eE") ~ Parser.charIn("+-").? ~ digits1).void
 
     (signedIntString ~ frac.? ~ exp.?).string
   }

--- a/core/shared/src/main/scala/cats/parse/Numbers.scala
+++ b/core/shared/src/main/scala/cats/parse/Numbers.scala
@@ -26,11 +26,11 @@ object Numbers {
   /** a single base 10 digit
     */
   val digit: Parser1[Char] =
-    Parser.charIn('0' to '9')
+    Parser0.charIn('0' to '9')
 
   /** zero or more digit chars
     */
-  val digits: Parser[String] = digit.rep.string
+  val digits: Parser0[String] = digit.rep.string
 
   /** one or more digit chars
     */
@@ -39,20 +39,20 @@ object Numbers {
   /** a single base 10 digit excluding 0
     */
   val nonZeroDigit: Parser1[Char] =
-    Parser.charIn('1' to '9')
+    Parser0.charIn('1' to '9')
 
   /** A String of either 1 '0' or
     * 1 non-zero digit followed by zero or more digits
     */
   val nonNegativeIntString: Parser1[String] =
     (nonZeroDigit ~ digits).void
-      .orElse1(Parser.char('0'))
+      .orElse1(Parser0.char('0'))
       .string
 
   /** A nonNegativeIntString possibly preceded by '-'
     */
   val signedIntString: Parser1[String] =
-    (Parser.char('-').?.with1 ~ nonNegativeIntString).string
+    (Parser0.char('-').?.with1 ~ nonNegativeIntString).string
 
   /** map a signedIntString into a BigInt
     */
@@ -75,8 +75,8 @@ object Numbers {
      *     plus = %x2B                ; +
      *     zero = %x30                ; 0
      */
-    val frac: Parser1[Any] = Parser.char('.') ~ digits1
-    val exp: Parser1[Unit] = (Parser.charIn("eE") ~ Parser.charIn("+-").? ~ digits1).void
+    val frac: Parser1[Any] = Parser0.char('.') ~ digits1
+    val exp: Parser1[Unit] = (Parser0.charIn("eE") ~ Parser0.charIn("+-").? ~ digits1).void
 
     (signedIntString ~ frac.? ~ exp.?).string
   }

--- a/core/shared/src/main/scala/cats/parse/Numbers.scala
+++ b/core/shared/src/main/scala/cats/parse/Numbers.scala
@@ -46,7 +46,7 @@ object Numbers {
     */
   val nonNegativeIntString: Parser[String] =
     (nonZeroDigit ~ digits).void
-      .orElse1(Parser0.char('0'))
+      .orElse(Parser0.char('0'))
       .string
 
   /** A nonNegativeIntString possibly preceded by '-'

--- a/core/shared/src/main/scala/cats/parse/Numbers.scala
+++ b/core/shared/src/main/scala/cats/parse/Numbers.scala
@@ -30,11 +30,11 @@ object Numbers {
 
   /** zero or more digit chars
     */
-  val digits: Parser0[String] = digit.rep.string
+  val digits: Parser0[String] = digit.rep0.string
 
   /** one or more digit chars
     */
-  val digits1: Parser[String] = digit.rep1.string
+  val digits1: Parser[String] = digit.rep.string
 
   /** a single base 10 digit excluding 0
     */

--- a/core/shared/src/main/scala/cats/parse/Numbers.scala
+++ b/core/shared/src/main/scala/cats/parse/Numbers.scala
@@ -30,11 +30,11 @@ object Numbers {
 
   /** zero or more digit chars
     */
-  val digits: Parser0[String] = digit.rep0.string
+  val digits0: Parser0[String] = digit.rep0.string
 
   /** one or more digit chars
     */
-  val digits1: Parser[String] = digit.rep.string
+  val digits: Parser[String] = digit.rep.string
 
   /** a single base 10 digit excluding 0
     */
@@ -45,7 +45,7 @@ object Numbers {
     * 1 non-zero digit followed by zero or more digits
     */
   val nonNegativeIntString: Parser[String] =
-    (nonZeroDigit ~ digits).void
+    (nonZeroDigit ~ digits0).void
       .orElse(Parser.char('0'))
       .string
 
@@ -75,8 +75,8 @@ object Numbers {
      *     plus = %x2B                ; +
      *     zero = %x30                ; 0
      */
-    val frac: Parser[Any] = Parser.char('.') ~ digits1
-    val exp: Parser[Unit] = (Parser.charIn("eE") ~ Parser.charIn("+-").? ~ digits1).void
+    val frac: Parser[Any] = Parser.char('.') ~ digits
+    val exp: Parser[Unit] = (Parser.charIn("eE") ~ Parser.charIn("+-").? ~ digits).void
 
     (signedIntString ~ frac.? ~ exp.?).string
   }

--- a/core/shared/src/main/scala/cats/parse/Numbers.scala
+++ b/core/shared/src/main/scala/cats/parse/Numbers.scala
@@ -25,7 +25,7 @@ object Numbers {
 
   /** a single base 10 digit
     */
-  val digit: Parser1[Char] =
+  val digit: Parser[Char] =
     Parser0.charIn('0' to '9')
 
   /** zero or more digit chars
@@ -34,35 +34,35 @@ object Numbers {
 
   /** one or more digit chars
     */
-  val digits1: Parser1[String] = digit.rep1.string
+  val digits1: Parser[String] = digit.rep1.string
 
   /** a single base 10 digit excluding 0
     */
-  val nonZeroDigit: Parser1[Char] =
+  val nonZeroDigit: Parser[Char] =
     Parser0.charIn('1' to '9')
 
   /** A String of either 1 '0' or
     * 1 non-zero digit followed by zero or more digits
     */
-  val nonNegativeIntString: Parser1[String] =
+  val nonNegativeIntString: Parser[String] =
     (nonZeroDigit ~ digits).void
       .orElse1(Parser0.char('0'))
       .string
 
   /** A nonNegativeIntString possibly preceded by '-'
     */
-  val signedIntString: Parser1[String] =
+  val signedIntString: Parser[String] =
     (Parser0.char('-').?.with1 ~ nonNegativeIntString).string
 
   /** map a signedIntString into a BigInt
     */
-  val bigInt: Parser1[BigInt] =
+  val bigInt: Parser[BigInt] =
     signedIntString.map(BigInt(_))
 
   /** A string matching the json specification for numbers.
     * from: https://tools.ietf.org/html/rfc4627
     */
-  val jsonNumber: Parser1[String] = {
+  val jsonNumber: Parser[String] = {
     /*
      *     number = [ minus ] int [ frac ] [ exp ]
      *     decimal-point = %x2E       ; .
@@ -75,8 +75,8 @@ object Numbers {
      *     plus = %x2B                ; +
      *     zero = %x30                ; 0
      */
-    val frac: Parser1[Any] = Parser0.char('.') ~ digits1
-    val exp: Parser1[Unit] = (Parser0.charIn("eE") ~ Parser0.charIn("+-").? ~ digits1).void
+    val frac: Parser[Any] = Parser0.char('.') ~ digits1
+    val exp: Parser[Unit] = (Parser0.charIn("eE") ~ Parser0.charIn("+-").? ~ digits1).void
 
     (signedIntString ~ frac.? ~ exp.?).string
   }

--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -1181,8 +1181,8 @@ object Parser {
       case s if Impl.alwaysSucceeds(s) => unit
       case _ =>
         Impl.unmap0(pa) match {
-          case Impl.StartParser0 => Impl.StartParser0
-          case Impl.EndParser0 => Impl.EndParser0
+          case Impl.StartParser => Impl.StartParser
+          case Impl.EndParser => Impl.EndParser
           case n @ Impl.Not(_) => n
           case p @ Impl.Peek(_) => p
           case other => Impl.Void0(other)
@@ -1277,11 +1277,11 @@ object Parser {
 
   /** succeeds when we are at the start
     */
-  def start: Parser0[Unit] = Impl.StartParser0
+  def start: Parser0[Unit] = Impl.StartParser
 
   /** succeeds when we are at the end
     */
-  def end: Parser0[Unit] = Impl.EndParser0
+  def end: Parser0[Unit] = Impl.EndParser
 
   /** If we fail, rewind the offset back so that
     * we can try other branches. This tends
@@ -1425,9 +1425,7 @@ object Parser {
     final def doesBacktrack(p: Parser0[Any]): Boolean =
       p match {
         case Backtrack0(_) | Backtrack(_) | AnyChar | CharIn(_, _, _) | Str(_) | IgnoreCase(_) |
-            Length(_) | StartParser0 | EndParser0 | Index | Pure(_) | Fail() | FailWith(_) | Not(
-              _
-            ) =>
+            Length(_) | StartParser | EndParser | Index | Pure(_) | Fail() | FailWith(_) | Not(_) =>
           true
         case Map(p, _) => doesBacktrack(p)
         case Map1(p, _) => doesBacktrack(p)
@@ -1517,7 +1515,7 @@ object Parser {
         case Defer0(fn) =>
           Defer0(() => unmap0(compute0(fn)))
         case Rep0(p, _) => Rep0(unmap(p), Accumulator0.unitAccumulator0)
-        case StartParser0 | EndParser0 | TailRecM0(_, _) | FlatMap0(_, _) =>
+        case StartParser | EndParser | TailRecM0(_, _) | FlatMap0(_, _) =>
           // we can't transform this significantly
           pa
       }
@@ -1671,7 +1669,7 @@ object Parser {
         Impl.string0(parser, state)
     }
 
-    case object StartParser0 extends Parser0[Unit] {
+    case object StartParser extends Parser0[Unit] {
       override def parseMut(state: State): Unit = {
         if (state.offset != 0) {
           state.error = Chain.one(Expectation.StartOfString(state.offset))
@@ -1680,7 +1678,7 @@ object Parser {
       }
     }
 
-    case object EndParser0 extends Parser0[Unit] {
+    case object EndParser extends Parser0[Unit] {
       override def parseMut(state: State): Unit = {
         if (state.offset != state.str.length) {
           state.error = Chain.one(Expectation.EndOfString(state.offset, state.str.length))

--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -1214,12 +1214,12 @@ object Parser {
     */
   def string0(pa: Parser0[Any]): Parser0[String] =
     pa match {
-      case str @ Impl.StringP(_) => str
+      case str @ Impl.StringP0(_) => str
       case s1: Parser[_] => string(s1)
       case _ =>
         Impl.unmap0(pa) match {
           case Impl.Pure(_) | Impl.Index => emptyStringParser0
-          case notEmpty => Impl.StringP(notEmpty)
+          case notEmpty => Impl.StringP0(notEmpty)
         }
     }
 
@@ -1228,7 +1228,7 @@ object Parser {
     */
   def string(pa: Parser[Any]): Parser[String] =
     pa match {
-      case str @ Impl.StringP1(_) => str
+      case str @ Impl.StringP(_) => str
       case _ =>
         Impl.unmap(pa) match {
           case len @ Impl.Length(_) => len
@@ -1241,7 +1241,7 @@ object Parser {
             // these are really Parser[Nothing]
             // but scala can't see that, so we cast
             f.asInstanceOf[Parser[String]]
-          case notStr => Impl.StringP1(notStr)
+          case notStr => Impl.StringP(notStr)
         }
     }
 
@@ -1465,7 +1465,7 @@ object Parser {
           unmap0(p)
         case Select0(p, fn) =>
           Select0(p, unmap0(fn))
-        case StringP(s) =>
+        case StringP0(s) =>
           // StringP is added privately, and only after unmap0
           s
         case Void0(v) =>
@@ -1542,7 +1542,7 @@ object Parser {
           unmap(p)
         case Select(p, fn) =>
           Select(p, unmap0(fn))
-        case StringP1(s) =>
+        case StringP(s) =>
           // StringP is added privately, and only after unmap
           s
         case Void(v) =>
@@ -1659,12 +1659,12 @@ object Parser {
       str
     }
 
-    case class StringP[A](parser: Parser0[A]) extends Parser0[String] {
+    case class StringP0[A](parser: Parser0[A]) extends Parser0[String] {
       override def parseMut(state: State): String =
         Impl.string0(parser, state)
     }
 
-    case class StringP1[A](parser: Parser[A]) extends Parser[String] {
+    case class StringP[A](parser: Parser[A]) extends Parser[String] {
       override def parseMut(state: State): String =
         Impl.string0(parser, state)
     }

--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -1055,17 +1055,17 @@ object Parser0 extends ParserInstances {
 
   /** Lazily create a Parser
     *  This is useful to create some recursive parsers
-    *  see Defer[Parser].fix
+    *  see Defer0[Parser].fix
     */
   def defer1[A](pa: => Parser[A]): Parser[A] =
-    Impl.Defer1(() => pa)
+    Impl.Defer(() => pa)
 
   /** Lazily create a Parser0
     *  This is useful to create some recursive parsers
-    *  see Defer[Parser].fix
+    *  see Defer0[Parser].fix
     */
   def defer[A](pa: => Parser0[A]): Parser0[A] =
-    Impl.Defer(() => pa)
+    Impl.Defer0(() => pa)
 
   /** A parser that always fails with an epsilon failure
     */
@@ -1511,8 +1511,8 @@ object Parser0 extends ParserInstances {
               if (u2 eq Parser0.unit) u1
               else SoftProd(u1, u2)
           }
-        case Defer(fn) =>
-          Defer(() => unmap(compute0(fn)))
+        case Defer0(fn) =>
+          Defer0(() => unmap(compute0(fn)))
         case Rep(p, _) => Rep(unmap1(p), Accumulator0.unitAccumulator0)
         case StartParser0 | EndParser0 | TailRecM(_, _) | FlatMap(_, _) =>
           // we can't transform this significantly
@@ -1593,8 +1593,8 @@ object Parser0 extends ParserInstances {
               if (u2 eq Parser0.unit) expect1(u1)
               else SoftProd1(u1, u2)
           }
-        case Defer1(fn) =>
-          Defer1(() => unmap1(compute(fn)))
+        case Defer(fn) =>
+          Defer(() => unmap1(compute(fn)))
         case Rep1(p, m, _) => Rep1(unmap1(p), m, Accumulator0.unitAccumulator0)
         case AnyChar | CharIn(_, _, _) | Str(_) | IgnoreCase(_) | Fail() | FailWith(_) | Length(_) |
             TailRecM1(_, _) | FlatMap1(_, _) =>
@@ -1954,18 +1954,18 @@ object Parser0 extends ParserInstances {
     @annotation.tailrec
     final def compute0[A](fn: () => Parser0[A]): Parser0[A] =
       fn() match {
-        case Defer1(f) => compute(f)
-        case Defer(f) => compute0(f)
-        case notDefer => notDefer
+        case Defer(f) => compute(f)
+        case Defer0(f) => compute0(f)
+        case notDefer0 => notDefer0
       }
     @annotation.tailrec
     final def compute[A](fn: () => Parser[A]): Parser[A] =
       fn() match {
-        case Defer1(f) => compute(f)
-        case notDefer => notDefer
+        case Defer(f) => compute(f)
+        case notDefer0 => notDefer0
       }
 
-    case class Defer1[A](fn: () => Parser[A]) extends Parser[A] {
+    case class Defer[A](fn: () => Parser[A]) extends Parser[A] {
       private[this] var computed: Parser0[A] = null
       override def parseMut(state: State): A = {
 
@@ -1982,7 +1982,7 @@ object Parser0 extends ParserInstances {
       }
     }
 
-    case class Defer[A](fn: () => Parser0[A]) extends Parser0[A] {
+    case class Defer0[A](fn: () => Parser0[A]) extends Parser0[A] {
       private[this] var computed: Parser0[A] = null
       override def parseMut(state: State): A = {
 

--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -366,7 +366,7 @@ sealed abstract class Parser[+A] extends Parser0[A] {
   /** This method overrides `Parser0#~` to refine the return type.
     */
   override def ~[B](that: Parser0[B]): Parser[(A, B)] =
-    Parser.product(this, that)
+    Parser.product10(this, that)
 
   /** Compose two parsers, ignoring the values extracted by the
     * left-hand parser.
@@ -891,7 +891,7 @@ object Parser {
     */
   def product0[A, B](first: Parser0[A], second: Parser0[B]): Parser0[(A, B)] =
     first match {
-      case f1: Parser[A] => product(f1, second)
+      case f1: Parser[A] => product10(f1, second)
       case _ =>
         second match {
           case s1: Parser[B] =>
@@ -902,7 +902,7 @@ object Parser {
 
   /** product with the first argument being a Parser
     */
-  def product[A, B](first: Parser[A], second: Parser0[B]): Parser[(A, B)] =
+  def product10[A, B](first: Parser[A], second: Parser0[B]): Parser[(A, B)] =
     Impl.Prod(first, second)
 
   /** product with the second argument being a Parser
@@ -1340,7 +1340,7 @@ object Parser {
         Parser.this.flatMap10(fa)(fn)
 
       override def product[A, B](pa: Parser[A], pb: Parser[B]): Parser[(A, B)] =
-        Parser.this.product(pa, pb)
+        Parser.this.product10(pa, pb)
 
       override def map2[A, B, C](pa: Parser[A], pb: Parser[B])(fn: (A, B) => C): Parser[C] =
         map(product(pa, pb)) { case (a, b) => fn(a, b) }

--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -110,7 +110,7 @@ sealed abstract class Parser0[+A] {
     * will still fail.
     */
   def ? : Parser0[Option[A]] =
-    Parser0.oneOf0(Parser0.map(this)(Some(_)) :: Parser0.Impl.optTail)
+    Parser0.oneOf0(Parser0.map0(this)(Some(_)) :: Parser0.Impl.optTail)
 
   /** Parse without capturing values.
     *
@@ -187,7 +187,7 @@ sealed abstract class Parser0[+A] {
     * `void` before `map` will improve the efficiency of the parser.
     */
   def map[B](fn: A => B): Parser0[B] =
-    Parser0.map(this)(fn)
+    Parser0.map0(this)(fn)
 
   /** Transform parsed values using the given function, or fail on None
     *
@@ -392,7 +392,7 @@ sealed abstract class Parser[+A] extends Parser0[A] {
   /** This method overrides `Parser0#map` to refine the return type.
     */
   override def map[B](fn: A => B): Parser[B] =
-    Parser0.map1(this)(fn)
+    Parser0.map(this)(fn)
 
   /** This method overrides `Parser0#mapFilter` to refine the return type.
     */
@@ -961,9 +961,9 @@ object Parser0 extends ParserInstances {
 
   /** transform a Parser0 result
     */
-  def map[A, B](p: Parser0[A])(fn: A => B): Parser0[B] =
+  def map0[A, B](p: Parser0[A])(fn: A => B): Parser0[B] =
     p match {
-      case p1: Parser[A] => map1(p1)(fn)
+      case p1: Parser[A] => map(p1)(fn)
       case Impl.Map(p0, f0) =>
         Impl.Map(p0, AndThen(f0).andThen(fn))
       case _ => Impl.Map(p, fn)
@@ -971,7 +971,7 @@ object Parser0 extends ParserInstances {
 
   /** transform a Parser result
     */
-  def map1[A, B](p: Parser[A])(fn: A => B): Parser[B] =
+  def map[A, B](p: Parser[A])(fn: A => B): Parser[B] =
     p match {
       case Impl.Map1(p0, f0) =>
         Impl.Map1(p0, AndThen(f0).andThen(fn))
@@ -1336,7 +1336,7 @@ object Parser0 extends ParserInstances {
       def functor = this
 
       def map[A, B](fa: Parser[A])(fn: A => B): Parser[B] =
-        map1(fa)(fn)
+        Parser0.this.map(fa)(fn)
 
       def mapFilter[A, B](fa: Parser[A])(f: A => Option[B]): Parser[B] =
         fa.mapFilter(f)
@@ -2244,7 +2244,7 @@ abstract class ParserInstances {
 
       def functor = this
 
-      override def map[A, B](fa: Parser0[A])(fn: A => B): Parser0[B] = Parser0.map(fa)(fn)
+      override def map[A, B](fa: Parser0[A])(fn: A => B): Parser0[B] = Parser0.map0(fa)(fn)
 
       def mapFilter[A, B](fa: Parser0[A])(f: A => Option[B]): Parser0[B] =
         fa.mapFilter(f)

--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -699,13 +699,13 @@ object Parser {
     */
   final class Soft[+A](parser: Parser[A]) extends Soft0(parser) {
     override def ~[B](that: Parser0[B]): Parser[(A, B)] =
-      softProduct(parser, that)
+      softProduct10(parser, that)
 
     override def *>[B](that: Parser0[B]): Parser[B] =
-      softProduct(void(parser), that).map(_._2)
+      softProduct10(void(parser), that).map(_._2)
 
     override def <*[B](that: Parser0[B]): Parser[A] =
-      softProduct(parser, void0(that)).map(_._1)
+      softProduct10(parser, void0(that)).map(_._1)
   }
 
   /** If we can parse this then that, do so,
@@ -919,7 +919,7 @@ object Parser {
     */
   def softProduct0[A, B](first: Parser0[A], second: Parser0[B]): Parser0[(A, B)] =
     first match {
-      case f1: Parser[A] => softProduct(f1, second)
+      case f1: Parser[A] => softProduct10(f1, second)
       case _ =>
         second match {
           case s1: Parser[B] =>
@@ -935,7 +935,7 @@ object Parser {
     *
     *  see @Parser.soft
     */
-  def softProduct[A, B](first: Parser[A], second: Parser0[B]): Parser[(A, B)] =
+  def softProduct10[A, B](first: Parser[A], second: Parser0[B]): Parser[(A, B)] =
     Impl.SoftProd(first, second)
 
   /** softProduct with the second argument being a Parser

--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -174,7 +174,7 @@ sealed abstract class Parser0[+A] {
     * one to pick up after any error, resetting any state that was
     * modified by the left parser.
     */
-  def orElse[A1 >: A](that: Parser0[A1]): Parser0[A1] =
+  def orElse0[A1 >: A](that: Parser0[A1]): Parser0[A1] =
     Parser0.oneOf(this :: that :: Nil)
 
   /** Transform parsed values using the given function.
@@ -425,7 +425,7 @@ sealed abstract class Parser[+A] extends Parser0[A] {
     * are known to be Parser values, the result is known to be a
     * Parser as well.
     */
-  def orElse1[A1 >: A](that: Parser[A1]): Parser[A1] =
+  def orElse[A1 >: A](that: Parser[A1]): Parser[A1] =
     Parser0.oneOf1(this :: that :: Nil)
 
   /** Use this parser to parse zero-or-more values.
@@ -786,7 +786,7 @@ object Parser0 extends ParserInstances {
     *  as long as they are epsilon failures (don't advance)
     *  see @backtrack if you want to do backtracking.
     *
-    *  This is the same as parsers.foldLeft(fail)(_.orElse1(_))
+    *  This is the same as parsers.foldLeft(fail)(_.orElse(_))
     */
   def oneOf1[A](parsers: List[Parser[A]]): Parser[A] = {
     @annotation.tailrec
@@ -813,7 +813,7 @@ object Parser0 extends ParserInstances {
     *  as long as they are epsilon failures (don't advance)
     *  see @backtrack if you want to do backtracking.
     *
-    *  This is the same as parsers.foldLeft(fail)(_.orElse(_))
+    *  This is the same as parsers.foldLeft(fail)(_.orElse0(_))
     */
   def oneOf[A](ps: List[Parser0[A]]): Parser0[A] = {
     @annotation.tailrec
@@ -2111,13 +2111,13 @@ object Parser0 extends ParserInstances {
     /*
      * Merge CharIn bitsets
      */
-    def mergeCharIn[A, P <: Parser0[A]](ps: List[P]): List[P] = {
+    def mergeCharIn[A, P0 <: Parser0[A]](ps: List[P0]): List[P0] = {
       @annotation.tailrec
-      def loop(ps: List[P], front: List[(Int, BitSetUtil.Tpe)], result: Chain[P]): Chain[P] = {
+      def loop(ps: List[P0], front: List[(Int, BitSetUtil.Tpe)], result: Chain[P0]): Chain[P0] = {
         @inline
-        def frontRes: Chain[P] =
+        def frontRes: Chain[P0] =
           if (front.isEmpty) Chain.nil
-          else Chain.one(Parser0.charIn(BitSetUtil.union(front)).asInstanceOf[P])
+          else Chain.one(Parser0.charIn(BitSetUtil.union(front)).asInstanceOf[P0])
 
         ps match {
           case Nil => result ++ frontRes
@@ -2125,7 +2125,7 @@ object Parser0 extends ParserInstances {
             // AnyChar is bigger than all subsequent CharIn:
             // and any direct prefix CharIns
             val tail1 = tail.filterNot(_.isInstanceOf[CharIn])
-            (result :+ AnyChar.asInstanceOf[P]) ++ Chain.fromSeq(tail1)
+            (result :+ AnyChar.asInstanceOf[P0]) ++ Chain.fromSeq(tail1)
           case CharIn(m, bs, _) :: tail =>
             loop(tail, (m, bs) :: front, result)
           case h :: tail =>

--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -1159,12 +1159,12 @@ object Parser0 extends ParserInstances {
 
   /** parse zero or more characters as long as they don't match p
     */
-  def until(p: Parser0[Any]): Parser0[String] =
+  def until0(p: Parser0[Any]): Parser0[String] =
     (not(p).with1 ~ anyChar).rep0.string
 
   /** parse one or more characters as long as they don't match p
     */
-  def until1(p: Parser0[Any]): Parser[String] =
+  def until(p: Parser0[Any]): Parser[String] =
     (not(p).with1 ~ anyChar).rep.string
 
   /** discard the value in a Parser0.

--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -846,15 +846,15 @@ object Parser0 extends ParserInstances {
     pure("")
 
   /** if len < 1, the same as pure("")
-    * else length1(len)
+    * else length(len)
     */
-  def length(len: Int): Parser0[String] =
-    if (len > 0) length1(len) else emptyStringParser0
+  def length0(len: Int): Parser0[String] =
+    if (len > 0) length(len) else emptyStringParser0
 
   /** Parse the next len characters where len > 0
     * if (len < 1) throw IllegalArgumentException
     */
-  def length1(len: Int): Parser[String] =
+  def length(len: Int): Parser[String] =
     Impl.Length(len)
 
   /** Repeat this parser 0 or more times

--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -244,7 +244,7 @@ sealed abstract class Parser0[+A] {
   /** Replaces parsed values with the given value.
     */
   def as[B](b: B): Parser0[B] =
-    Parser0.as(this, b)
+    Parser0.as0(this, b)
 
   /** Wrap this parser in a helper class, enabling better composition
     * with `Parser` values.
@@ -416,7 +416,7 @@ sealed abstract class Parser[+A] extends Parser0[A] {
   /** This method overrides `Parser0#as` to refine the return type.
     */
   override def as[B](b: B): Parser[B] =
-    Parser0.as1(this, b)
+    Parser0.as(this, b)
 
   /** If this parser fails to parse its input with an epsilon error,
     * try the given parser instead.
@@ -1307,16 +1307,16 @@ object Parser0 extends ParserInstances {
 
   /** Replaces parsed values with the given value.
     */
-  def as[A, B](pa: Parser0[A], b: B): Parser0[B] =
+  def as0[A, B](pa: Parser0[A], b: B): Parser0[B] =
     pa match {
       case Impl.Pure(_) | Impl.Index => pure(b)
-      case p1: Parser[A] => as1(p1, b)
+      case p1: Parser[A] => as(p1, b)
       case _ => pa.void.map(Impl.ConstFn(b))
     }
 
   /** Replaces parsed values with the given value.
     */
-  def as1[A, B](pa: Parser[A], b: B): Parser[B] =
+  def as[A, B](pa: Parser[A], b: B): Parser[B] =
     (pa.void, b) match {
       case (Impl.Void(ci @ Impl.CharIn(min, bs, _)), bc: Char)
           if BitSetUtil.isSingleton(bs) && (min.toChar == bc) =>
@@ -1377,7 +1377,7 @@ object Parser0 extends ParserInstances {
         pa.void
 
       override def as[A, B](pa: Parser[A], b: B): Parser[B] =
-        Parser0.as1(pa, b)
+        Parser0.as(pa, b)
 
       override def productL[A, B](pa: Parser[A])(pb: Parser[B]): Parser[A] =
         map(product(pa, pb.void)) { case (a, _) => a }
@@ -2285,7 +2285,7 @@ abstract class ParserInstances {
         Parser0.void0(pa)
 
       override def as[A, B](pa: Parser0[A], b: B): Parser0[B] =
-        Parser0.as(pa, b)
+        Parser0.as0(pa, b)
 
       override def productL[A, B](pa: Parser0[A])(pb: Parser0[B]): Parser0[A] =
         map(product(pa, pb.void)) { case (a, _) => a }

--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -122,7 +122,7 @@ sealed abstract class Parser0[+A] {
     * result.
     */
   def void: Parser0[Unit] =
-    Parser0.void(this)
+    Parser0.void0(this)
 
   /** Return the string matched by this parser.
     *
@@ -135,7 +135,7 @@ sealed abstract class Parser0[+A] {
     * allocating results to return.
     */
   def string: Parser0[String] =
-    Parser0.string(this)
+    Parser0.string0(this)
 
   /** If this parser fails to match, rewind the offset to the starting
     * point before moving on to other parser.
@@ -351,12 +351,12 @@ sealed abstract class Parser[+A] extends Parser0[A] {
   /** This method overrides `Parser0#void` to refine the return type.
     */
   override def void: Parser[Unit] =
-    Parser0.void1(this)
+    Parser0.void(this)
 
   /** This method overrides `Parser0#string` to refine the return type.
     */
   override def string: Parser[String] =
-    Parser0.string1(this)
+    Parser0.string(this)
 
   /** This method overrides `Parser0#backtrack` to refine the return type.
     */
@@ -639,13 +639,13 @@ object Parser0 extends ParserInstances {
       *  Since that is a Parser the result is
       */
     def *>[B](that: Parser[B]): Parser[B] =
-      product01(void(parser), that).map(_._2)
+      product01(void0(parser), that).map(_._2)
 
     /** parser then that.
       *  Since that is a Parser the result is
       */
     def <*[B](that: Parser[B]): Parser[A] =
-      product01(parser, void1(that)).map(_._1)
+      product01(parser, void(that)).map(_._1)
 
     /** If we can parse this then that, do so,
       * if we fail that without consuming, rewind
@@ -678,10 +678,10 @@ object Parser0 extends ParserInstances {
       softProduct(parser, that)
 
     def *>[B](that: Parser0[B]): Parser0[B] =
-      softProduct(void(parser), that).map(_._2)
+      softProduct(void0(parser), that).map(_._2)
 
     def <*[B](that: Parser0[B]): Parser0[A] =
-      softProduct(parser, void(that)).map(_._1)
+      softProduct(parser, void0(that)).map(_._1)
 
     /** If we can parse this then that, do so,
       * if we fail that without consuming, rewind
@@ -702,10 +702,10 @@ object Parser0 extends ParserInstances {
       softProduct10(parser, that)
 
     override def *>[B](that: Parser0[B]): Parser[B] =
-      softProduct10(void1(parser), that).map(_._2)
+      softProduct10(void(parser), that).map(_._2)
 
     override def <*[B](that: Parser0[B]): Parser[A] =
-      softProduct10(parser, void(that)).map(_._1)
+      softProduct10(parser, void0(that)).map(_._1)
   }
 
   /** If we can parse this then that, do so,
@@ -718,10 +718,10 @@ object Parser0 extends ParserInstances {
       softProduct01(parser, that)
 
     def *>[B](that: Parser[B]): Parser[B] =
-      softProduct01(void(parser), that).map(_._2)
+      softProduct01(void0(parser), that).map(_._2)
 
     def <*[B](that: Parser[B]): Parser[A] =
-      softProduct01(parser, void1(that)).map(_._1)
+      softProduct01(parser, void(that)).map(_._1)
   }
 
   /** Methods with complex variance type signatures due to covariance.
@@ -764,16 +764,16 @@ object Parser0 extends ParserInstances {
     * fail. This backtracks on failure
     * this is an error if the string is empty
     */
-  def string1(str: String): Parser[Unit] =
+  def string(str: String): Parser[Unit] =
     if (str.length == 1) char(str.charAt(0))
     else Impl.Str(str)
 
   /** Parse a potentially empty string or
     * fail. This backtracks on failure
     */
-  def string(str: String): Parser0[Unit] =
+  def string0(str: String): Parser0[Unit] =
     if (str.length == 0) unit
-    else string1(str)
+    else string(str)
 
   /** Parse a potentially empty string, in a case-insensitive manner,
     * or fail. This backtracks on failure
@@ -1173,10 +1173,10 @@ object Parser0 extends ParserInstances {
     *  This function is called internal to Functor.as and Apply.*>
     *  and Apply.<* so those are good uses.
     */
-  def void(pa: Parser0[Any]): Parser0[Unit] =
+  def void0(pa: Parser0[Any]): Parser0[Unit] =
     pa match {
-      case v @ Impl.Void(_) => v
-      case p1: Parser[_] => void1(p1)
+      case v @ Impl.Void0(_) => v
+      case p1: Parser[_] => void(p1)
       case s if Impl.alwaysSucceeds(s) => unit
       case _ =>
         Impl.unmap0(pa) match {
@@ -1184,7 +1184,7 @@ object Parser0 extends ParserInstances {
           case Impl.EndParser0 => Impl.EndParser0
           case n @ Impl.Not(_) => n
           case p @ Impl.Peek(_) => p
-          case other => Impl.Void(other)
+          case other => Impl.Void0(other)
         }
     }
 
@@ -1194,9 +1194,9 @@ object Parser0 extends ParserInstances {
     *  This function is called internal to Functor.as and Apply.*>
     *  and Apply.<* so those are good uses.
     */
-  def void1(pa: Parser[Any]): Parser[Unit] =
+  def void(pa: Parser[Any]): Parser[Unit] =
     pa match {
-      case v @ Impl.Void1(_) => v
+      case v @ Impl.Void(_) => v
       case _ =>
         Impl.unmap(pa) match {
           case f @ (Impl.Fail() | Impl.FailWith(_)) =>
@@ -1204,17 +1204,17 @@ object Parser0 extends ParserInstances {
             // but scala can't see that, so we cast
             f.asInstanceOf[Parser[Unit]]
           case p: Impl.Str => p
-          case notVoid => Impl.Void1(notVoid)
+          case notVoid => Impl.Void(notVoid)
         }
     }
 
   /** Discard the result A and instead capture the matching string
     *  this is optimized to avoid internal allocations
     */
-  def string(pa: Parser0[Any]): Parser0[String] =
+  def string0(pa: Parser0[Any]): Parser0[String] =
     pa match {
       case str @ Impl.StringP(_) => str
-      case s1: Parser[_] => string1(s1)
+      case s1: Parser[_] => string(s1)
       case _ =>
         Impl.unmap0(pa) match {
           case Impl.Pure(_) | Impl.Index => emptyStringParser0
@@ -1225,7 +1225,7 @@ object Parser0 extends ParserInstances {
   /** Discard the result A and instead capture the matching string
     *  this is optimized to avoid internal allocations
     */
-  def string1(pa: Parser[Any]): Parser[String] =
+  def string(pa: Parser[Any]): Parser[String] =
     pa match {
       case str @ Impl.StringP1(_) => str
       case _ =>
@@ -1249,7 +1249,7 @@ object Parser0 extends ParserInstances {
     * Note, this parser backtracks (never returns an arresting failure)
     */
   def not(pa: Parser0[Any]): Parser0[Unit] =
-    void(pa) match {
+    void0(pa) match {
       case Impl.Fail() | Impl.FailWith(_) => unit
       case notFail => Impl.Not(notFail)
     }
@@ -1265,7 +1265,7 @@ object Parser0 extends ParserInstances {
         // TODO: we can adjust Rep0/Rep to do minimal
         // work since we rewind after we are sure there is
         // a match
-        Impl.Peek(void(notPeek))
+        Impl.Peek(void0(notPeek))
     }
 
   /** return the current position in the string
@@ -1318,7 +1318,7 @@ object Parser0 extends ParserInstances {
     */
   def as1[A, B](pa: Parser[A], b: B): Parser[B] =
     (pa.void, b) match {
-      case (Impl.Void1(ci @ Impl.CharIn(min, bs, _)), bc: Char)
+      case (Impl.Void(ci @ Impl.CharIn(min, bs, _)), bc: Char)
           if BitSetUtil.isSingleton(bs) && (min.toChar == bc) =>
         // this is putting the character back on a singleton CharIn, just return the char in
         ci.asInstanceOf[Parser[B]]
@@ -1467,7 +1467,7 @@ object Parser0 extends ParserInstances {
         case StringP(s) =>
           // StringP is added privately, and only after unmap0
           s
-        case Void(v) =>
+        case Void0(v) =>
           // Void is added privately, and only after unmap0
           v
         case n @ Not(_) =>
@@ -1488,7 +1488,7 @@ object Parser0 extends ParserInstances {
               // we can check matches a bit faster
               // note: p12 is already unmapped, so
               // we wrap with Void to prevent n^2 cost
-              Prod(p11, unmap0(Prod(Void(p12), p2)))
+              Prod(p11, unmap0(Prod(Void0(p12), p2)))
             case u1 if u1 eq Parser0.unit =>
               unmap0(p2)
             case u1 =>
@@ -1503,7 +1503,7 @@ object Parser0 extends ParserInstances {
               // we can check matches a bit faster
               // note: p12 is already unmapped, so
               // we wrap with Void to prevent n^2 cost
-              SoftProd(p11, unmap0(SoftProd(Void(p12), p2)))
+              SoftProd(p11, unmap0(SoftProd(Void0(p12), p2)))
             case u1 if u1 eq Parser0.unit =>
               unmap0(p2)
             case u1 =>
@@ -1544,7 +1544,7 @@ object Parser0 extends ParserInstances {
         case StringP1(s) =>
           // StringP is added privately, and only after unmap
           s
-        case Void1(v) =>
+        case Void(v) =>
           // Void is added privately, and only after unmap
           v
         case Backtrack1(p) =>
@@ -1638,17 +1638,17 @@ object Parser0 extends ParserInstances {
       ()
     }
 
-    case class Void[A](parser: Parser0[A]) extends Parser0[Unit] {
+    case class Void0[A](parser: Parser0[A]) extends Parser0[Unit] {
       override def parseMut(state: State): Unit =
         Impl.void(parser, state)
     }
 
-    case class Void1[A](parser: Parser[A]) extends Parser[Unit] {
+    case class Void[A](parser: Parser[A]) extends Parser[Unit] {
       override def parseMut(state: State): Unit =
         Impl.void(parser, state)
     }
 
-    def string(pa: Parser0[Any], state: State): String = {
+    def string0(pa: Parser0[Any], state: State): String = {
       val s0 = state.capture
       state.capture = false
       val init = state.offset
@@ -1660,12 +1660,12 @@ object Parser0 extends ParserInstances {
 
     case class StringP[A](parser: Parser0[A]) extends Parser0[String] {
       override def parseMut(state: State): String =
-        Impl.string(parser, state)
+        Impl.string0(parser, state)
     }
 
     case class StringP1[A](parser: Parser[A]) extends Parser[String] {
       override def parseMut(state: State): String =
-        Impl.string(parser, state)
+        Impl.string0(parser, state)
     }
 
     case object StartParser0 extends Parser0[Unit] {
@@ -2282,7 +2282,7 @@ abstract class ParserInstances {
         Parser0.tailRecM(init)(fn)
 
       override def void[A](pa: Parser0[A]): Parser0[Unit] =
-        Parser0.void(pa)
+        Parser0.void0(pa)
 
       override def as[A, B](pa: Parser0[A], b: B): Parser0[B] =
         Parser0.as(pa, b)

--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -793,7 +793,7 @@ object Parser0 extends ParserInstances {
     def flatten(ls: List[Parser[A]], acc: ListBuffer[Parser[A]]): List[Parser[A]] =
       ls match {
         case Nil => acc.toList.distinct
-        case Impl.OneOf1(ps) :: rest =>
+        case Impl.OneOf(ps) :: rest =>
           flatten(ps ::: rest, acc)
         case Impl.Fail() :: rest =>
           flatten(rest, acc)
@@ -805,7 +805,7 @@ object Parser0 extends ParserInstances {
     Impl.mergeCharIn[A, Parser[A]](flat) match {
       case Nil => fail
       case p :: Nil => p
-      case two => Impl.OneOf1(two)
+      case two => Impl.OneOf(two)
     }
   }
 
@@ -820,9 +820,9 @@ object Parser0 extends ParserInstances {
     def flatten(ls: List[Parser0[A]], acc: ListBuffer[Parser0[A]]): List[Parser0[A]] =
       ls match {
         case Nil => acc.toList.distinct
-        case Impl.OneOf(ps) :: rest =>
+        case Impl.OneOf0(ps) :: rest =>
           flatten(ps ::: rest, acc)
-        case Impl.OneOf1(ps) :: rest =>
+        case Impl.OneOf(ps) :: rest =>
           flatten(ps ::: rest, acc)
         case Impl.Fail() :: rest =>
           flatten(rest, acc)
@@ -838,7 +838,7 @@ object Parser0 extends ParserInstances {
     Impl.mergeCharIn[A, Parser0[A]](flat) match {
       case Nil => fail
       case p :: Nil => p
-      case two => Impl.OneOf(two)
+      case two => Impl.OneOf0(two)
     }
   }
 
@@ -1480,7 +1480,7 @@ object Parser0 extends ParserInstances {
           // unmap may simplify enough
           // to remove the backtrack wrapper
           Parser0.backtrack(unmap(p))
-        case OneOf(ps) => Parser0.oneOf(ps.map(unmap))
+        case OneOf0(ps) => Parser0.oneOf(ps.map(unmap))
         case Prod(p1, p2) =>
           unmap(p1) match {
             case Prod(p11, p12) =>
@@ -1551,7 +1551,7 @@ object Parser0 extends ParserInstances {
           // unmap may simplify enough
           // to remove the backtrack wrapper
           Parser0.backtrack1(unmap1(p))
-        case OneOf1(ps) => Parser0.oneOf1(ps.map(unmap1))
+        case OneOf(ps) => Parser0.oneOf1(ps.map(unmap1))
         case Prod1(p1, p2) =>
           unmap(p1) match {
             case Prod(p11, p12) =>
@@ -1782,14 +1782,14 @@ object Parser0 extends ParserInstances {
       null.asInstanceOf[A]
     }
 
-    case class OneOf1[A](all: List[Parser[A]]) extends Parser[A] {
+    case class OneOf[A](all: List[Parser[A]]) extends Parser[A] {
       require(all.lengthCompare(2) >= 0, s"expected more than two items, found: ${all.size}")
       private[this] val ary: Array[Parser0[A]] = all.toArray
 
       override def parseMut(state: State): A = oneOf(ary, state)
     }
 
-    case class OneOf[A](all: List[Parser0[A]]) extends Parser0[A] {
+    case class OneOf0[A](all: List[Parser0[A]]) extends Parser0[A] {
       require(all.lengthCompare(2) >= 0, s"expected more than two items, found: ${all.size}")
       private[this] val ary = all.toArray
 

--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -411,7 +411,7 @@ sealed abstract class Parser[+A] extends Parser0[A] {
   /** This method overrides `Parser0#flatMap` to refine the return type.
     */
   override def flatMap[B](fn: A => Parser0[B]): Parser[B] =
-    Parser.flatMap(this)(fn)
+    Parser.flatMap10(this)(fn)
 
   /** This method overrides `Parser0#as` to refine the return type.
     */
@@ -1010,7 +1010,7 @@ object Parser {
     *  flatMap always has to allocate a parser, and the
     *  parser is less amenable to optimization
     */
-  def flatMap[A, B](pa: Parser[A])(fn: A => Parser0[B]): Parser[B] =
+  def flatMap10[A, B](pa: Parser[A])(fn: A => Parser0[B]): Parser[B] =
     Impl.FlatMap(pa, fn)
 
   /** Standard monadic flatMap where you end with a Parser
@@ -1337,7 +1337,7 @@ object Parser {
         fa.filter { a => !fn(a) }
 
       def flatMap[A, B](fa: Parser[A])(fn: A => Parser[B]): Parser[B] =
-        Parser.this.flatMap(fa)(fn)
+        Parser.this.flatMap10(fa)(fn)
 
       override def product[A, B](pa: Parser[A], pb: Parser[B]): Parser[(A, B)] =
         Parser.this.product(pa, pb)

--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -881,7 +881,7 @@ object Parser0 extends ParserInstances {
 
   /** Repeat 1 or more times with a separator
     */
-  def rep1Sep[A](p1: Parser[A], min: Int, sep: Parser0[Any]): Parser[NonEmptyList[A]] = {
+  def repSep[A](p1: Parser[A], min: Int, sep: Parser0[Any]): Parser[NonEmptyList[A]] = {
     if (min <= 0) throw new IllegalArgumentException(s"require min > 0, found: $min")
 
     val rest = (sep.void.with1.soft *> p1).rep0(min - 1)
@@ -890,12 +890,12 @@ object Parser0 extends ParserInstances {
 
   /** Repeat 0 or more times with a separator
     */
-  def repSep[A](p1: Parser[A], min: Int, sep: Parser0[Any]): Parser0[List[A]] = {
-    if (min <= 0) rep1Sep(p1, 1, sep).?.map {
+  def rep0Sep[A](p1: Parser[A], min: Int, sep: Parser0[Any]): Parser0[List[A]] = {
+    if (min <= 0) repSep(p1, 1, sep).?.map {
       case None => Nil
       case Some(nel) => nel.toList
     }
-    else rep1Sep(p1, min, sep).map(_.toList)
+    else repSep(p1, min, sep).map(_.toList)
   }
 
   /** parse first then second

--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -439,7 +439,7 @@ sealed abstract class Parser[+A] extends Parser0[A] {
     * list as a successful parse.
     */
   def rep0: Parser0[List[A]] =
-    Parser.rep0(this)
+    Parser.repAs0[A, List[A]](this)
 
   /** Use this parser to parse at least `min` values (where `min >= 0`).
     *
@@ -464,7 +464,7 @@ sealed abstract class Parser[+A] extends Parser0[A] {
     * parses.
     */
   def rep: Parser[NonEmptyList[A]] =
-    Parser.rep(this, min = 1)
+    Parser.repAs(this, min = 1)
 
   /** Use this parser to parse at least `min` values (where `min >= 1`).
     *
@@ -472,7 +472,7 @@ sealed abstract class Parser[+A] extends Parser0[A] {
     * values are produced an arresting failure will be returned.
     */
   def rep(min: Int): Parser[NonEmptyList[A]] =
-    Parser.rep(this, min = min)
+    Parser.repAs(this, min = min)
 
   /** This method overrides `Parser0#between` to refine the return type
     */
@@ -860,19 +860,8 @@ object Parser {
   /** Repeat this parser 0 or more times
     * note: this can wind up parsing nothing
     */
-  def rep0[A](p1: Parser[A]): Parser0[List[A]] =
-    repAs0[A, List[A]](p1)
-
-  /** Repeat this parser 0 or more times
-    * note: this can wind up parsing nothing
-    */
   def repAs0[A, B](p1: Parser[A])(implicit acc: Accumulator0[A, B]): Parser0[B] =
     Impl.Rep0(p1, acc)
-
-  /** Repeat this parser 1 or more times
-    */
-  def rep[A](p1: Parser[A], min: Int): Parser[NonEmptyList[A]] =
-    repAs[A, NonEmptyList[A]](p1, min)
 
   /** Repeat this parser 1 or more times
     */

--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -1057,14 +1057,14 @@ object Parser0 extends ParserInstances {
     *  This is useful to create some recursive parsers
     *  see Defer0[Parser].fix
     */
-  def defer1[A](pa: => Parser[A]): Parser[A] =
+  def defer[A](pa: => Parser[A]): Parser[A] =
     Impl.Defer(() => pa)
 
   /** Lazily create a Parser0
     *  This is useful to create some recursive parsers
     *  see Defer0[Parser].fix
     */
-  def defer[A](pa: => Parser0[A]): Parser0[A] =
+  def defer0[A](pa: => Parser0[A]): Parser0[A] =
     Impl.Defer0(() => pa)
 
   /** A parser that always fails with an epsilon failure
@@ -1331,7 +1331,7 @@ object Parser0 extends ParserInstances {
       def empty[A] = Fail
 
       def defer[A](pa: => Parser[A]): Parser[A] =
-        defer1(pa)
+        Parser0.this.defer(pa)
 
       def functor = this
 
@@ -2238,7 +2238,7 @@ abstract class ParserInstances {
     new Monad[Parser0] with Alternative[Parser0] with Defer[Parser0] with FunctorFilter[Parser0] {
       def pure[A](a: A): Parser0[A] = Parser0.pure(a)
 
-      def defer[A](a: => Parser0[A]) = Parser0.defer(a)
+      def defer[A](a: => Parser0[A]) = Parser0.defer0(a)
 
       def empty[A]: Parser0[A] = Parser0.Fail
 

--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -747,7 +747,7 @@ object Parser0 extends ParserInstances {
     * or fail. This backtracks on failure
     * this is an error if the string is empty
     */
-  def ignoreCase1(str: String): Parser[Unit] =
+  def ignoreCase(str: String): Parser[Unit] =
     if (str.length == 1) {
       ignoreCaseChar(str.charAt(0))
     } else Impl.IgnoreCase(str.toLowerCase)
@@ -778,9 +778,9 @@ object Parser0 extends ParserInstances {
   /** Parse a potentially empty string, in a case-insensitive manner,
     * or fail. This backtracks on failure
     */
-  def ignoreCase(str: String): Parser0[Unit] =
+  def ignoreCase0(str: String): Parser0[Unit] =
     if (str.length == 0) unit
-    else ignoreCase1(str)
+    else ignoreCase(str)
 
   /** go through the list of parsers trying each
     *  as long as they are epsilon failures (don't advance)

--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -490,9 +490,7 @@ sealed abstract class Parser[+A] extends Parser0[A] {
     new Parser.Soft(this)
 }
 
-object Parser0 extends ParserInstances {
-  
-}
+object Parser0 extends ParserInstances {}
 object Parser {
 
   /** An expectation reports the kind or parsing error
@@ -1427,7 +1425,9 @@ object Parser {
     final def doesBacktrack(p: Parser0[Any]): Boolean =
       p match {
         case Backtrack0(_) | Backtrack(_) | AnyChar | CharIn(_, _, _) | Str(_) | IgnoreCase(_) |
-            Length(_) | StartParser0 | EndParser0 | Index | Pure(_) | Fail() | FailWith(_) | Not(_) =>
+            Length(_) | StartParser0 | EndParser0 | Index | Pure(_) | Fail() | FailWith(_) | Not(
+              _
+            ) =>
           true
         case Map(p, _) => doesBacktrack(p)
         case Map1(p, _) => doesBacktrack(p)

--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -1179,7 +1179,7 @@ object Parser0 extends ParserInstances {
       case p1: Parser[_] => void1(p1)
       case s if Impl.alwaysSucceeds(s) => unit
       case _ =>
-        Impl.unmap(pa) match {
+        Impl.unmap0(pa) match {
           case Impl.StartParser0 => Impl.StartParser0
           case Impl.EndParser0 => Impl.EndParser0
           case n @ Impl.Not(_) => n
@@ -1198,7 +1198,7 @@ object Parser0 extends ParserInstances {
     pa match {
       case v @ Impl.Void1(_) => v
       case _ =>
-        Impl.unmap1(pa) match {
+        Impl.unmap(pa) match {
           case f @ (Impl.Fail() | Impl.FailWith(_)) =>
             // these are really Parser[Nothing]
             // but scala can't see that, so we cast
@@ -1216,7 +1216,7 @@ object Parser0 extends ParserInstances {
       case str @ Impl.StringP(_) => str
       case s1: Parser[_] => string1(s1)
       case _ =>
-        Impl.unmap(pa) match {
+        Impl.unmap0(pa) match {
           case Impl.Pure(_) | Impl.Index => emptyStringParser0
           case notEmpty => Impl.StringP(notEmpty)
         }
@@ -1229,7 +1229,7 @@ object Parser0 extends ParserInstances {
     pa match {
       case str @ Impl.StringP1(_) => str
       case _ =>
-        Impl.unmap1(pa) match {
+        Impl.unmap(pa) match {
           case len @ Impl.Length(_) => len
           case strP @ Impl.Str(expect) => strP.as(expect)
           case ci @ Impl.CharIn(min, bs, _) if BitSetUtil.isSingleton(bs) =>
@@ -1454,21 +1454,21 @@ object Parser0 extends ParserInstances {
       * at StringP or VoidP since those are markers
       * that anything below has already been transformed
       */
-    def unmap(pa: Parser0[Any]): Parser0[Any] =
+    def unmap0(pa: Parser0[Any]): Parser0[Any] =
       pa match {
-        case p1: Parser[Any] => unmap1(p1)
+        case p1: Parser[Any] => unmap(p1)
         case Pure(_) | Index => Parser0.unit
         case s if alwaysSucceeds(s) => Parser0.unit
         case Map(p, _) =>
           // we discard any allocations done by fn
-          unmap(p)
+          unmap0(p)
         case Select(p, fn) =>
-          Select(p, unmap(fn))
+          Select(p, unmap0(fn))
         case StringP(s) =>
-          // StringP is added privately, and only after unmap
+          // StringP is added privately, and only after unmap0
           s
         case Void(v) =>
-          // Void is added privately, and only after unmap
+          // Void is added privately, and only after unmap0
           v
         case n @ Not(_) =>
           // not is already voided
@@ -1477,43 +1477,43 @@ object Parser0 extends ParserInstances {
           // peek is already voided
           p
         case Backtrack(p) =>
-          // unmap may simplify enough
+          // unmap0 may simplify enough
           // to remove the backtrack wrapper
-          Parser0.backtrack(unmap(p))
-        case OneOf0(ps) => Parser0.oneOf0(ps.map(unmap))
+          Parser0.backtrack(unmap0(p))
+        case OneOf0(ps) => Parser0.oneOf0(ps.map(unmap0))
         case Prod(p1, p2) =>
-          unmap(p1) match {
+          unmap0(p1) match {
             case Prod(p11, p12) =>
               // right associate so
               // we can check matches a bit faster
               // note: p12 is already unmapped, so
               // we wrap with Void to prevent n^2 cost
-              Prod(p11, unmap(Prod(Void(p12), p2)))
+              Prod(p11, unmap0(Prod(Void(p12), p2)))
             case u1 if u1 eq Parser0.unit =>
-              unmap(p2)
+              unmap0(p2)
             case u1 =>
-              val u2 = unmap(p2)
+              val u2 = unmap0(p2)
               if (u2 eq Parser0.unit) u1
               else Prod(u1, u2)
           }
         case SoftProd(p1, p2) =>
-          unmap(p1) match {
+          unmap0(p1) match {
             case SoftProd(p11, p12) =>
               // right associate so
               // we can check matches a bit faster
               // note: p12 is already unmapped, so
               // we wrap with Void to prevent n^2 cost
-              SoftProd(p11, unmap(SoftProd(Void(p12), p2)))
+              SoftProd(p11, unmap0(SoftProd(Void(p12), p2)))
             case u1 if u1 eq Parser0.unit =>
-              unmap(p2)
+              unmap0(p2)
             case u1 =>
-              val u2 = unmap(p2)
+              val u2 = unmap0(p2)
               if (u2 eq Parser0.unit) u1
               else SoftProd(u1, u2)
           }
         case Defer0(fn) =>
-          Defer0(() => unmap(compute0(fn)))
-        case Rep0(p, _) => Rep0(unmap1(p), Accumulator0.unitAccumulator0)
+          Defer0(() => unmap0(compute0(fn)))
+        case Rep0(p, _) => Rep0(unmap(p), Accumulator0.unitAccumulator0)
         case StartParser0 | EndParser0 | TailRecM(_, _) | FlatMap(_, _) =>
           // we can't transform this significantly
           pa
@@ -1534,13 +1534,13 @@ object Parser0 extends ParserInstances {
       * at StringP or VoidP since those are markers
       * that anything below has already been transformed
       */
-    def unmap1(pa: Parser[Any]): Parser[Any] =
+    def unmap(pa: Parser[Any]): Parser[Any] =
       pa match {
         case Map1(p, _) =>
           // we discard any allocations done by fn
-          unmap1(p)
+          unmap(p)
         case Select1(p, fn) =>
-          Select1(p, unmap(fn))
+          Select1(p, unmap0(fn))
         case StringP1(s) =>
           // StringP is added privately, and only after unmap
           s
@@ -1550,52 +1550,52 @@ object Parser0 extends ParserInstances {
         case Backtrack1(p) =>
           // unmap may simplify enough
           // to remove the backtrack wrapper
-          Parser0.backtrack1(unmap1(p))
-        case OneOf(ps) => Parser0.oneOf(ps.map(unmap1))
+          Parser0.backtrack1(unmap(p))
+        case OneOf(ps) => Parser0.oneOf(ps.map(unmap))
         case Prod1(p1, p2) =>
-          unmap(p1) match {
+          unmap0(p1) match {
             case Prod(p11, p12) =>
               // right associate so
               // we can check matches a bit faster
               // note: p12 is already unmapped, so
               // we wrap with Void to prevent n^2 cost
-              Prod1(p11, unmap(Parser0.product(p12.void, p2)))
+              Prod1(p11, unmap0(Parser0.product(p12.void, p2)))
             case Prod1(p11, p12) =>
               // right associate so
               // we can check matches a bit faster
               // we wrap with Void to prevent n^2 cost
-              Prod1(p11, unmap(Parser0.product(p12.void, p2)))
+              Prod1(p11, unmap0(Parser0.product(p12.void, p2)))
             case u1 if u1 eq Parser0.unit =>
-              // if unmap(u1) is unit, p2 must be a Parser
-              unmap1(expect1(p2))
+              // if unmap0(u1) is unit, p2 must be a Parser
+              unmap(expect1(p2))
             case u1 =>
-              val u2 = unmap(p2)
+              val u2 = unmap0(p2)
               if (u2 eq Parser0.unit) expect1(u1)
               else Prod1(u1, u2)
           }
         case SoftProd1(p1, p2) =>
-          unmap(p1) match {
+          unmap0(p1) match {
             case SoftProd(p11, p12) =>
               // right associate so
               // we can check matches a bit faster
               // we wrap with Void to prevent n^2 cost
-              SoftProd1(p11, unmap(Parser0.softProduct(p12.void, p2)))
+              SoftProd1(p11, unmap0(Parser0.softProduct(p12.void, p2)))
             case SoftProd1(p11, p12) =>
               // right associate so
               // we can check matches a bit faster
               // we wrap with Void to prevent n^2 cost
-              SoftProd1(p11, unmap(Parser0.softProduct(p12.void, p2)))
+              SoftProd1(p11, unmap0(Parser0.softProduct(p12.void, p2)))
             case u1 if u1 eq Parser0.unit =>
-              // if unmap(u1) is unit, p2 must be a Parser
-              unmap1(expect1(p2))
+              // if unmap0(u1) is unit, p2 must be a Parser
+              unmap(expect1(p2))
             case u1 =>
-              val u2 = unmap(p2)
+              val u2 = unmap0(p2)
               if (u2 eq Parser0.unit) expect1(u1)
               else SoftProd1(u1, u2)
           }
         case Defer(fn) =>
-          Defer(() => unmap1(compute(fn)))
-        case Rep(p, m, _) => Rep(unmap1(p), m, Accumulator0.unitAccumulator0)
+          Defer(() => unmap(compute(fn)))
+        case Rep(p, m, _) => Rep(unmap(p), m, Accumulator0.unitAccumulator0)
         case AnyChar | CharIn(_, _, _) | Str(_) | IgnoreCase(_) | Fail() | FailWith(_) | Length(_) |
             TailRecM1(_, _) | FlatMap1(_, _) =>
           // we can't transform this significantly

--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -278,8 +278,8 @@ sealed abstract class Parser0[+A] {
     * y)`, if `x` parses successfully, and `y` returns an epsilon
     * failure, the parser will "rewind" to the point before `x` began.
     */
-  def soft: Parser0.Soft[A] =
-    new Parser0.Soft(this)
+  def soft: Parser0.Soft0[A] =
+    new Parser0.Soft0(this)
 
   /** Return a parser that succeeds (consuming nothing, and extracting
     * nothing) if the current parser would fail.
@@ -486,8 +486,8 @@ sealed abstract class Parser[+A] extends Parser0[A] {
 
   /** This method overrides `Parser0#soft` to refine the return type.
     */
-  override def soft: Parser0.Soft10[A] =
-    new Parser0.Soft10(this)
+  override def soft: Parser0.Soft[A] =
+    new Parser0.Soft(this)
 }
 
 object Parser0 extends ParserInstances {
@@ -673,7 +673,7 @@ object Parser0 extends ParserInstances {
     * before this without consuming.
     * If either consume 1 or more, do not rewind
     */
-  sealed class Soft[+A](parser: Parser0[A]) {
+  sealed class Soft0[+A](parser: Parser0[A]) {
     def ~[B](that: Parser0[B]): Parser0[(A, B)] =
       softProduct0(parser, that)
 
@@ -697,7 +697,7 @@ object Parser0 extends ParserInstances {
     * before this without consuming.
     * If either consume 1 or more, do not rewind
     */
-  final class Soft10[+A](parser: Parser[A]) extends Soft(parser) {
+  final class Soft[+A](parser: Parser[A]) extends Soft0(parser) {
     override def ~[B](that: Parser0[B]): Parser[(A, B)] =
       softProduct(parser, that)
 

--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -867,7 +867,7 @@ object Parser0 extends ParserInstances {
     * note: this can wind up parsing nothing
     */
   def repAs0[A, B](p1: Parser[A])(implicit acc: Accumulator0[A, B]): Parser0[B] =
-    Impl.Rep(p1, acc)
+    Impl.Rep0(p1, acc)
 
   /** Repeat this parser 1 or more times
     */
@@ -877,7 +877,7 @@ object Parser0 extends ParserInstances {
   /** Repeat this parser 1 or more times
     */
   def repAs[A, B](p1: Parser[A], min: Int)(implicit acc: Accumulator[A, B]): Parser[B] =
-    Impl.Rep1(p1, min, acc)
+    Impl.Rep(p1, min, acc)
 
   /** Repeat 1 or more times with a separator
     */
@@ -1262,7 +1262,7 @@ object Parser0 extends ParserInstances {
       case peek @ Impl.Peek(_) => peek
       case s if Impl.alwaysSucceeds(s) => unit
       case notPeek =>
-        // TODO: we can adjust Rep/Rep1 to do minimal
+        // TODO: we can adjust Rep0/Rep to do minimal
         // work since we rewind after we are sure there is
         // a match
         Impl.Peek(void(notPeek))
@@ -1513,7 +1513,7 @@ object Parser0 extends ParserInstances {
           }
         case Defer0(fn) =>
           Defer0(() => unmap(compute0(fn)))
-        case Rep(p, _) => Rep(unmap1(p), Accumulator0.unitAccumulator0)
+        case Rep0(p, _) => Rep0(unmap1(p), Accumulator0.unitAccumulator0)
         case StartParser0 | EndParser0 | TailRecM(_, _) | FlatMap(_, _) =>
           // we can't transform this significantly
           pa
@@ -1595,7 +1595,7 @@ object Parser0 extends ParserInstances {
           }
         case Defer(fn) =>
           Defer(() => unmap1(compute(fn)))
-        case Rep1(p, m, _) => Rep1(unmap1(p), m, Accumulator0.unitAccumulator0)
+        case Rep(p, m, _) => Rep(unmap1(p), m, Accumulator0.unitAccumulator0)
         case AnyChar | CharIn(_, _, _) | Str(_) | IgnoreCase(_) | Fail() | FailWith(_) | Length(_) |
             TailRecM1(_, _) | FlatMap1(_, _) =>
           // we can't transform this significantly
@@ -2057,7 +2057,7 @@ object Parser0 extends ParserInstances {
       }
     }
 
-    case class Rep[A, B](p1: Parser[A], acc: Accumulator0[A, B]) extends Parser0[B] {
+    case class Rep0[A, B](p1: Parser[A], acc: Accumulator0[A, B]) extends Parser0[B] {
       private[this] val ignore: B = null.asInstanceOf[B]
 
       override def parseMut(state: State): B = {
@@ -2072,7 +2072,7 @@ object Parser0 extends ParserInstances {
       }
     }
 
-    case class Rep1[A, B](p1: Parser[A], min: Int, acc1: Accumulator[A, B]) extends Parser[B] {
+    case class Rep[A, B](p1: Parser[A], min: Int, acc1: Accumulator[A, B]) extends Parser[B] {
       if (min < 1) throw new IllegalArgumentException(s"expected min >= 1, found: $min")
 
       private[this] val ignore: B = null.asInstanceOf[B]

--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -1512,7 +1512,7 @@ object Parser0 extends ParserInstances {
               else SoftProd(u1, u2)
           }
         case Defer(fn) =>
-          Defer(() => unmap(compute(fn)))
+          Defer(() => unmap(compute0(fn)))
         case Rep(p, _) => Rep(unmap1(p), Accumulator0.unitAccumulator0)
         case StartParser0 | EndParser0 | TailRecM(_, _) | FlatMap(_, _) =>
           // we can't transform this significantly
@@ -1594,7 +1594,7 @@ object Parser0 extends ParserInstances {
               else SoftProd1(u1, u2)
           }
         case Defer1(fn) =>
-          Defer1(() => unmap1(compute1(fn)))
+          Defer1(() => unmap1(compute(fn)))
         case Rep1(p, m, _) => Rep1(unmap1(p), m, Accumulator0.unitAccumulator0)
         case AnyChar | CharIn(_, _, _) | Str(_) | IgnoreCase(_) | Fail() | FailWith(_) | Length(_) |
             TailRecM1(_, _) | FlatMap1(_, _) =>
@@ -1952,16 +1952,16 @@ object Parser0 extends ParserInstances {
     }
 
     @annotation.tailrec
-    final def compute[A](fn: () => Parser0[A]): Parser0[A] =
+    final def compute0[A](fn: () => Parser0[A]): Parser0[A] =
       fn() match {
-        case Defer1(f) => compute1(f)
-        case Defer(f) => compute(f)
+        case Defer1(f) => compute(f)
+        case Defer(f) => compute0(f)
         case notDefer => notDefer
       }
     @annotation.tailrec
-    final def compute1[A](fn: () => Parser[A]): Parser[A] =
+    final def compute[A](fn: () => Parser[A]): Parser[A] =
       fn() match {
-        case Defer1(f) => compute1(f)
+        case Defer1(f) => compute(f)
         case notDefer => notDefer
       }
 
@@ -1973,7 +1973,7 @@ object Parser0 extends ParserInstances {
         val p =
           if (p0 ne null) p0
           else {
-            val res = compute1(fn)
+            val res = compute(fn)
             computed = res
             res
           }
@@ -1990,7 +1990,7 @@ object Parser0 extends ParserInstances {
         val p =
           if (p0 ne null) p0
           else {
-            val res = compute(fn)
+            val res = compute0(fn)
             computed = res
             res
           }

--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -490,7 +490,6 @@ sealed abstract class Parser[+A] extends Parser0[A] {
     new Parser.Soft(this)
 }
 
-object Parser0 extends ParserInstances {}
 object Parser {
 
   /** An expectation reports the kind or parsing error
@@ -2233,7 +2232,8 @@ object Parser {
   }
 }
 
-abstract class ParserInstances {
+//holds just the typeclass instances, and brings them in implicit scope
+object Parser0 {
   implicit val catInstancesParser0
       : Monad[Parser0] with Alternative[Parser0] with Defer[Parser0] with FunctorFilter[Parser0] =
     new Monad[Parser0] with Alternative[Parser0] with Defer[Parser0] with FunctorFilter[Parser0] {

--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -1148,13 +1148,13 @@ object Parser0 extends ParserInstances {
 
   /** Parse a string while the given function is true
     */
-  def charsWhile(fn: Char => Boolean): Parser0[String] =
+  def charsWhile0(fn: Char => Boolean): Parser0[String] =
     charWhere(fn).rep0.string
 
   /** Parse a string while the given function is true
     * parses at least one character
     */
-  def charsWhile1(fn: Char => Boolean): Parser[String] =
+  def charsWhile(fn: Char => Boolean): Parser[String] =
     charWhere(fn).rep.string
 
   /** parse zero or more characters as long as they don't match p

--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -1369,7 +1369,7 @@ object Parser {
         map(product(pf, pa)) { case (fn, a) => fn(a) }
 
       def tailRecM[A, B](init: A)(fn: A => Parser[Either[A, B]]): Parser[B] =
-        Parser0.this.tailRecM(init)(fn)
+        Parser.this.tailRecM(init)(fn)
 
       def combineK[A](pa: Parser[A], pb: Parser[A]): Parser[A] =
         Parser.oneOf(pa :: pb :: Nil)
@@ -2280,7 +2280,7 @@ abstract class ParserInstances {
         Parser.oneOf0(pa :: pb :: Nil)
 
       def tailRecM[A, B](init: A)(fn: A => Parser0[Either[A, B]]): Parser0[B] =
-        Parser0.tailRecM0(init)(fn)
+        Parser.tailRecM0(init)(fn)
 
       override def void[A](pa: Parser0[A]): Parser0[Unit] =
         Parser.void0(pa)

--- a/core/shared/src/main/scala/cats/parse/Rfc5234.scala
+++ b/core/shared/src/main/scala/cats/parse/Rfc5234.scala
@@ -99,7 +99,7 @@ object Rfc5234 {
     * other contexts.
     */
   val lwsp: Parser0[Unit] =
-    Parser.rep0(wsp.orElse(crlf *> wsp)).void
+    Parser.repAs0[Unit, List[Unit]](wsp.orElse(crlf *> wsp)).void
 
   /** 8 bits of data
     */

--- a/core/shared/src/main/scala/cats/parse/Rfc5234.scala
+++ b/core/shared/src/main/scala/cats/parse/Rfc5234.scala
@@ -31,35 +31,35 @@ object Rfc5234 {
   /** A-Z and a-z, without diacritics
     */
   val alpha: Parser1[Char] =
-    Parser.charIn('A' to 'Z').orElse1(Parser.charIn('a' to 'z'))
+    Parser0.charIn('A' to 'Z').orElse1(Parser0.charIn('a' to 'z'))
 
   /** `0` or `1`
     */
   val bit: Parser1[Char] =
-    Parser.charIn('0' to '1')
+    Parser0.charIn('0' to '1')
 
   /** any 7-bit US-ASCII character, excluding NUL
     */
   val char: Parser1[Char] =
-    Parser.charIn(0x01.toChar to 0x7f.toChar)
+    Parser0.charIn(0x01.toChar to 0x7f.toChar)
 
   /** carriage return
     */
   val cr: Parser1[Unit] =
-    Parser.char('\r')
+    Parser0.char('\r')
 
   /** linefeed
     */
   val lf: Parser1[Unit] =
-    Parser.char('\n')
+    Parser0.char('\n')
 
   /** Internet standard newline */
   val crlf: Parser1[Unit] =
-    Parser.string1("\r\n")
+    Parser0.string1("\r\n")
 
   /** controls */
   val ctl: Parser1[Char] =
-    Parser.charIn(0x7f, (0x00.toChar to 0x1f.toChar): _*)
+    Parser0.charIn(0x7f, (0x00.toChar to 0x1f.toChar): _*)
 
   /** `0` to `9`
     */
@@ -69,21 +69,21 @@ object Rfc5234 {
   /** double quote (`"`)
     */
   val dquote: Parser1[Unit] =
-    Parser.char('"')
+    Parser0.char('"')
 
   /** hexadecimal digit, case insensitive
     */
   val hexdig: Parser1[Char] =
-    digit.orElse1(Parser.ignoreCaseCharIn('A' to 'F'))
+    digit.orElse1(Parser0.ignoreCaseCharIn('A' to 'F'))
 
   /** horizontal tab
     */
   val htab: Parser1[Unit] =
-    Parser.char('\t')
+    Parser0.char('\t')
 
   /** space */
   val sp: Parser1[Unit] =
-    Parser.char(' ')
+    Parser0.char(' ')
 
   /** white space (space or horizontal tab) */
   val wsp: Parser1[Unit] =
@@ -98,16 +98,16 @@ object Rfc5234 {
     * Do not use when defining mail headers and use with caution in
     * other contexts.
     */
-  val lwsp: Parser[Unit] =
-    Parser.rep(wsp.orElse1(crlf *> wsp)).void
+  val lwsp: Parser0[Unit] =
+    Parser0.rep(wsp.orElse1(crlf *> wsp)).void
 
   /** 8 bits of data
     */
   val octet: Parser1[Char] =
-    Parser.charIn(0x00.toChar to 0xff.toChar)
+    Parser0.charIn(0x00.toChar to 0xff.toChar)
 
   /** visible (printing) characters
     */
   val vchar: Parser1[Char] =
-    Parser.charIn(0x21.toChar to 0x7e.toChar)
+    Parser0.charIn(0x21.toChar to 0x7e.toChar)
 }

--- a/core/shared/src/main/scala/cats/parse/Rfc5234.scala
+++ b/core/shared/src/main/scala/cats/parse/Rfc5234.scala
@@ -55,7 +55,7 @@ object Rfc5234 {
 
   /** Internet standard newline */
   val crlf: Parser[Unit] =
-    Parser0.string1("\r\n")
+    Parser0.string("\r\n")
 
   /** controls */
   val ctl: Parser[Char] =

--- a/core/shared/src/main/scala/cats/parse/Rfc5234.scala
+++ b/core/shared/src/main/scala/cats/parse/Rfc5234.scala
@@ -31,35 +31,35 @@ object Rfc5234 {
   /** A-Z and a-z, without diacritics
     */
   val alpha: Parser[Char] =
-    Parser0.charIn('A' to 'Z').orElse(Parser0.charIn('a' to 'z'))
+    Parser.charIn('A' to 'Z').orElse(Parser.charIn('a' to 'z'))
 
   /** `0` or `1`
     */
   val bit: Parser[Char] =
-    Parser0.charIn('0' to '1')
+    Parser.charIn('0' to '1')
 
   /** any 7-bit US-ASCII character, excluding NUL
     */
   val char: Parser[Char] =
-    Parser0.charIn(0x01.toChar to 0x7f.toChar)
+    Parser.charIn(0x01.toChar to 0x7f.toChar)
 
   /** carriage return
     */
   val cr: Parser[Unit] =
-    Parser0.char('\r')
+    Parser.char('\r')
 
   /** linefeed
     */
   val lf: Parser[Unit] =
-    Parser0.char('\n')
+    Parser.char('\n')
 
   /** Internet standard newline */
   val crlf: Parser[Unit] =
-    Parser0.string("\r\n")
+    Parser.string("\r\n")
 
   /** controls */
   val ctl: Parser[Char] =
-    Parser0.charIn(0x7f, (0x00.toChar to 0x1f.toChar): _*)
+    Parser.charIn(0x7f, (0x00.toChar to 0x1f.toChar): _*)
 
   /** `0` to `9`
     */
@@ -69,21 +69,21 @@ object Rfc5234 {
   /** double quote (`"`)
     */
   val dquote: Parser[Unit] =
-    Parser0.char('"')
+    Parser.char('"')
 
   /** hexadecimal digit, case insensitive
     */
   val hexdig: Parser[Char] =
-    digit.orElse(Parser0.ignoreCaseCharIn('A' to 'F'))
+    digit.orElse(Parser.ignoreCaseCharIn('A' to 'F'))
 
   /** horizontal tab
     */
   val htab: Parser[Unit] =
-    Parser0.char('\t')
+    Parser.char('\t')
 
   /** space */
   val sp: Parser[Unit] =
-    Parser0.char(' ')
+    Parser.char(' ')
 
   /** white space (space or horizontal tab) */
   val wsp: Parser[Unit] =
@@ -99,15 +99,15 @@ object Rfc5234 {
     * other contexts.
     */
   val lwsp: Parser0[Unit] =
-    Parser0.rep0(wsp.orElse(crlf *> wsp)).void
+    Parser.rep0(wsp.orElse(crlf *> wsp)).void
 
   /** 8 bits of data
     */
   val octet: Parser[Char] =
-    Parser0.charIn(0x00.toChar to 0xff.toChar)
+    Parser.charIn(0x00.toChar to 0xff.toChar)
 
   /** visible (printing) characters
     */
   val vchar: Parser[Char] =
-    Parser0.charIn(0x21.toChar to 0x7e.toChar)
+    Parser.charIn(0x21.toChar to 0x7e.toChar)
 }

--- a/core/shared/src/main/scala/cats/parse/Rfc5234.scala
+++ b/core/shared/src/main/scala/cats/parse/Rfc5234.scala
@@ -31,7 +31,7 @@ object Rfc5234 {
   /** A-Z and a-z, without diacritics
     */
   val alpha: Parser[Char] =
-    Parser0.charIn('A' to 'Z').orElse1(Parser0.charIn('a' to 'z'))
+    Parser0.charIn('A' to 'Z').orElse(Parser0.charIn('a' to 'z'))
 
   /** `0` or `1`
     */
@@ -74,7 +74,7 @@ object Rfc5234 {
   /** hexadecimal digit, case insensitive
     */
   val hexdig: Parser[Char] =
-    digit.orElse1(Parser0.ignoreCaseCharIn('A' to 'F'))
+    digit.orElse(Parser0.ignoreCaseCharIn('A' to 'F'))
 
   /** horizontal tab
     */
@@ -87,7 +87,7 @@ object Rfc5234 {
 
   /** white space (space or horizontal tab) */
   val wsp: Parser[Unit] =
-    sp.orElse1(htab)
+    sp.orElse(htab)
 
   /** linear white space.
     *
@@ -99,7 +99,7 @@ object Rfc5234 {
     * other contexts.
     */
   val lwsp: Parser0[Unit] =
-    Parser0.rep(wsp.orElse1(crlf *> wsp)).void
+    Parser0.rep(wsp.orElse(crlf *> wsp)).void
 
   /** 8 bits of data
     */

--- a/core/shared/src/main/scala/cats/parse/Rfc5234.scala
+++ b/core/shared/src/main/scala/cats/parse/Rfc5234.scala
@@ -30,63 +30,63 @@ object Rfc5234 {
 
   /** A-Z and a-z, without diacritics
     */
-  val alpha: Parser1[Char] =
+  val alpha: Parser[Char] =
     Parser0.charIn('A' to 'Z').orElse1(Parser0.charIn('a' to 'z'))
 
   /** `0` or `1`
     */
-  val bit: Parser1[Char] =
+  val bit: Parser[Char] =
     Parser0.charIn('0' to '1')
 
   /** any 7-bit US-ASCII character, excluding NUL
     */
-  val char: Parser1[Char] =
+  val char: Parser[Char] =
     Parser0.charIn(0x01.toChar to 0x7f.toChar)
 
   /** carriage return
     */
-  val cr: Parser1[Unit] =
+  val cr: Parser[Unit] =
     Parser0.char('\r')
 
   /** linefeed
     */
-  val lf: Parser1[Unit] =
+  val lf: Parser[Unit] =
     Parser0.char('\n')
 
   /** Internet standard newline */
-  val crlf: Parser1[Unit] =
+  val crlf: Parser[Unit] =
     Parser0.string1("\r\n")
 
   /** controls */
-  val ctl: Parser1[Char] =
+  val ctl: Parser[Char] =
     Parser0.charIn(0x7f, (0x00.toChar to 0x1f.toChar): _*)
 
   /** `0` to `9`
     */
-  val digit: Parser1[Char] =
+  val digit: Parser[Char] =
     Numbers.digit
 
   /** double quote (`"`)
     */
-  val dquote: Parser1[Unit] =
+  val dquote: Parser[Unit] =
     Parser0.char('"')
 
   /** hexadecimal digit, case insensitive
     */
-  val hexdig: Parser1[Char] =
+  val hexdig: Parser[Char] =
     digit.orElse1(Parser0.ignoreCaseCharIn('A' to 'F'))
 
   /** horizontal tab
     */
-  val htab: Parser1[Unit] =
+  val htab: Parser[Unit] =
     Parser0.char('\t')
 
   /** space */
-  val sp: Parser1[Unit] =
+  val sp: Parser[Unit] =
     Parser0.char(' ')
 
   /** white space (space or horizontal tab) */
-  val wsp: Parser1[Unit] =
+  val wsp: Parser[Unit] =
     sp.orElse1(htab)
 
   /** linear white space.
@@ -103,11 +103,11 @@ object Rfc5234 {
 
   /** 8 bits of data
     */
-  val octet: Parser1[Char] =
+  val octet: Parser[Char] =
     Parser0.charIn(0x00.toChar to 0xff.toChar)
 
   /** visible (printing) characters
     */
-  val vchar: Parser1[Char] =
+  val vchar: Parser[Char] =
     Parser0.charIn(0x21.toChar to 0x7e.toChar)
 }

--- a/core/shared/src/main/scala/cats/parse/Rfc5234.scala
+++ b/core/shared/src/main/scala/cats/parse/Rfc5234.scala
@@ -99,7 +99,7 @@ object Rfc5234 {
     * other contexts.
     */
   val lwsp: Parser0[Unit] =
-    Parser0.rep(wsp.orElse(crlf *> wsp)).void
+    Parser0.rep0(wsp.orElse(crlf *> wsp)).void
 
   /** 8 bits of data
     */

--- a/core/shared/src/main/scala/cats/parse/SemVer.scala
+++ b/core/shared/src/main/scala/cats/parse/SemVer.scala
@@ -38,9 +38,9 @@ object SemVer {
 
   def positiveDigit: Parser[Char] = Numbers.nonZeroDigit
 
-  val nonDigit: Parser[Char] = letter.orElse1(hyphen)
+  val nonDigit: Parser[Char] = letter.orElse(hyphen)
 
-  val identifierChar: Parser[Char] = Numbers.digit.orElse1(nonDigit)
+  val identifierChar: Parser[Char] = Numbers.digit.orElse(nonDigit)
 
   val identifierChars: Parser[String] = identifierChar.rep1.string
 

--- a/core/shared/src/main/scala/cats/parse/SemVer.scala
+++ b/core/shared/src/main/scala/cats/parse/SemVer.scala
@@ -30,11 +30,11 @@ object SemVer {
 
   case class SemVer(core: Core, preRelease: Option[String], buildMetadata: Option[String])
 
-  val dot: Parser[Char] = Parser0.charIn('.')
-  val hyphen: Parser[Char] = Parser0.charIn('-')
-  val plus: Parser[Char] = Parser0.charIn('+')
+  val dot: Parser[Char] = Parser.charIn('.')
+  val hyphen: Parser[Char] = Parser.charIn('-')
+  val plus: Parser[Char] = Parser.charIn('+')
 
-  val letter: Parser[Char] = Parser0.ignoreCaseCharIn('a' to 'z')
+  val letter: Parser[Char] = Parser.ignoreCaseCharIn('a' to 'z')
 
   def positiveDigit: Parser[Char] = Numbers.nonZeroDigit
 
@@ -52,12 +52,12 @@ object SemVer {
 
   val preReleaseIdentifier: Parser[String] = alphanumericIdentifier
 
-  val dotSeparatedBuildIdentifiers: Parser[String] = Parser0.repSep(buildIdentifier, 1, dot).string
+  val dotSeparatedBuildIdentifiers: Parser[String] = Parser.repSep(buildIdentifier, 1, dot).string
 
   val build: Parser[String] = dotSeparatedBuildIdentifiers
 
   val dotSeparatedPreReleaseIdentifiers: Parser[String] =
-    Parser0.repSep(preReleaseIdentifier, 1, dot).string
+    Parser.repSep(preReleaseIdentifier, 1, dot).string
 
   val preRelease: Parser[String] = dotSeparatedPreReleaseIdentifiers
 

--- a/core/shared/src/main/scala/cats/parse/SemVer.scala
+++ b/core/shared/src/main/scala/cats/parse/SemVer.scala
@@ -42,7 +42,7 @@ object SemVer {
 
   val identifierChar: Parser[Char] = Numbers.digit.orElse(nonDigit)
 
-  val identifierChars: Parser[String] = identifierChar.rep1.string
+  val identifierChars: Parser[String] = identifierChar.rep.string
 
   def numericIdentifier: Parser[String] = Numbers.nonNegativeIntString
 

--- a/core/shared/src/main/scala/cats/parse/SemVer.scala
+++ b/core/shared/src/main/scala/cats/parse/SemVer.scala
@@ -52,12 +52,12 @@ object SemVer {
 
   val preReleaseIdentifier: Parser[String] = alphanumericIdentifier
 
-  val dotSeparatedBuildIdentifiers: Parser[String] = Parser0.rep1Sep(buildIdentifier, 1, dot).string
+  val dotSeparatedBuildIdentifiers: Parser[String] = Parser0.repSep(buildIdentifier, 1, dot).string
 
   val build: Parser[String] = dotSeparatedBuildIdentifiers
 
   val dotSeparatedPreReleaseIdentifiers: Parser[String] =
-    Parser0.rep1Sep(preReleaseIdentifier, 1, dot).string
+    Parser0.repSep(preReleaseIdentifier, 1, dot).string
 
   val preRelease: Parser[String] = dotSeparatedPreReleaseIdentifiers
 

--- a/core/shared/src/main/scala/cats/parse/SemVer.scala
+++ b/core/shared/src/main/scala/cats/parse/SemVer.scala
@@ -30,47 +30,47 @@ object SemVer {
 
   case class SemVer(core: Core, preRelease: Option[String], buildMetadata: Option[String])
 
-  val dot: Parser1[Char] = Parser0.charIn('.')
-  val hyphen: Parser1[Char] = Parser0.charIn('-')
-  val plus: Parser1[Char] = Parser0.charIn('+')
+  val dot: Parser[Char] = Parser0.charIn('.')
+  val hyphen: Parser[Char] = Parser0.charIn('-')
+  val plus: Parser[Char] = Parser0.charIn('+')
 
-  val letter: Parser1[Char] = Parser0.ignoreCaseCharIn('a' to 'z')
+  val letter: Parser[Char] = Parser0.ignoreCaseCharIn('a' to 'z')
 
-  def positiveDigit: Parser1[Char] = Numbers.nonZeroDigit
+  def positiveDigit: Parser[Char] = Numbers.nonZeroDigit
 
-  val nonDigit: Parser1[Char] = letter.orElse1(hyphen)
+  val nonDigit: Parser[Char] = letter.orElse1(hyphen)
 
-  val identifierChar: Parser1[Char] = Numbers.digit.orElse1(nonDigit)
+  val identifierChar: Parser[Char] = Numbers.digit.orElse1(nonDigit)
 
-  val identifierChars: Parser1[String] = identifierChar.rep1.string
+  val identifierChars: Parser[String] = identifierChar.rep1.string
 
-  def numericIdentifier: Parser1[String] = Numbers.nonNegativeIntString
+  def numericIdentifier: Parser[String] = Numbers.nonNegativeIntString
 
-  val alphanumericIdentifier: Parser1[String] = identifierChars
+  val alphanumericIdentifier: Parser[String] = identifierChars
 
-  val buildIdentifier: Parser1[String] = alphanumericIdentifier
+  val buildIdentifier: Parser[String] = alphanumericIdentifier
 
-  val preReleaseIdentifier: Parser1[String] = alphanumericIdentifier
+  val preReleaseIdentifier: Parser[String] = alphanumericIdentifier
 
-  val dotSeparatedBuildIdentifiers: Parser1[String] = Parser0.rep1Sep(buildIdentifier, 1, dot).string
+  val dotSeparatedBuildIdentifiers: Parser[String] = Parser0.rep1Sep(buildIdentifier, 1, dot).string
 
-  val build: Parser1[String] = dotSeparatedBuildIdentifiers
+  val build: Parser[String] = dotSeparatedBuildIdentifiers
 
-  val dotSeparatedPreReleaseIdentifiers: Parser1[String] =
+  val dotSeparatedPreReleaseIdentifiers: Parser[String] =
     Parser0.rep1Sep(preReleaseIdentifier, 1, dot).string
 
-  val preRelease: Parser1[String] = dotSeparatedPreReleaseIdentifiers
+  val preRelease: Parser[String] = dotSeparatedPreReleaseIdentifiers
 
-  val patch: Parser1[String] = numericIdentifier
-  val minor: Parser1[String] = numericIdentifier
-  val major: Parser1[String] = numericIdentifier
+  val patch: Parser[String] = numericIdentifier
+  val minor: Parser[String] = numericIdentifier
+  val major: Parser[String] = numericIdentifier
 
-  val core: Parser1[Core] = (major, dot *> minor, dot *> patch).mapN(Core)
-  val coreString: Parser1[String] = core.string
+  val core: Parser[Core] = (major, dot *> minor, dot *> patch).mapN(Core)
+  val coreString: Parser[String] = core.string
 
-  val semver: Parser1[SemVer] =
+  val semver: Parser[SemVer] =
     (core ~ (hyphen *> preRelease).? ~ (plus *> build).?).map { case ((c, p), b) =>
       SemVer(c, p, b)
     }
-  val semverString: Parser1[String] = semver.string
+  val semverString: Parser[String] = semver.string
 }

--- a/core/shared/src/main/scala/cats/parse/SemVer.scala
+++ b/core/shared/src/main/scala/cats/parse/SemVer.scala
@@ -30,11 +30,11 @@ object SemVer {
 
   case class SemVer(core: Core, preRelease: Option[String], buildMetadata: Option[String])
 
-  val dot: Parser1[Char] = Parser.charIn('.')
-  val hyphen: Parser1[Char] = Parser.charIn('-')
-  val plus: Parser1[Char] = Parser.charIn('+')
+  val dot: Parser1[Char] = Parser0.charIn('.')
+  val hyphen: Parser1[Char] = Parser0.charIn('-')
+  val plus: Parser1[Char] = Parser0.charIn('+')
 
-  val letter: Parser1[Char] = Parser.ignoreCaseCharIn('a' to 'z')
+  val letter: Parser1[Char] = Parser0.ignoreCaseCharIn('a' to 'z')
 
   def positiveDigit: Parser1[Char] = Numbers.nonZeroDigit
 
@@ -52,12 +52,12 @@ object SemVer {
 
   val preReleaseIdentifier: Parser1[String] = alphanumericIdentifier
 
-  val dotSeparatedBuildIdentifiers: Parser1[String] = Parser.rep1Sep(buildIdentifier, 1, dot).string
+  val dotSeparatedBuildIdentifiers: Parser1[String] = Parser0.rep1Sep(buildIdentifier, 1, dot).string
 
   val build: Parser1[String] = dotSeparatedBuildIdentifiers
 
   val dotSeparatedPreReleaseIdentifiers: Parser1[String] =
-    Parser.rep1Sep(preReleaseIdentifier, 1, dot).string
+    Parser0.rep1Sep(preReleaseIdentifier, 1, dot).string
 
   val preRelease: Parser1[String] = dotSeparatedPreReleaseIdentifiers
 

--- a/core/shared/src/test/scala/cats/parse/ParserTest.scala
+++ b/core/shared/src/test/scala/cats/parse/ParserTest.scala
@@ -74,79 +74,79 @@ object ParserGen {
   val pures: Gen[GenT[Gen]] =
     Gen.oneOf(arbGen[Int], arbGen[Boolean], arbGen[String], arbGen[(Int, Int)])
 
-  val expect0: Gen[GenT[Parser]] =
+  val expect0: Gen[GenT[Parser0]] =
     Arbitrary.arbitrary[String].map { str =>
-      GenT(Parser.string(str))
+      GenT(Parser0.string(str))
     }
 
-  val ignoreCase: Gen[GenT[Parser]] =
+  val ignoreCase: Gen[GenT[Parser0]] =
     Arbitrary.arbitrary[String].map { str =>
-      GenT(Parser.ignoreCase(str))
+      GenT(Parser0.ignoreCase(str))
     }
 
-  val charIn: Gen[GenT[Parser]] =
+  val charIn: Gen[GenT[Parser0]] =
     Gen.oneOf(
       Arbitrary.arbitrary[List[Char]].map { cs =>
-        GenT(Parser.charIn(cs): Parser[Char])
+        GenT(Parser0.charIn(cs): Parser0[Char])
       },
-      Gen.const(GenT(Parser.anyChar: Parser[Char]))
+      Gen.const(GenT(Parser0.anyChar: Parser0[Char]))
     )
 
   val charIn1: Gen[GenT[Parser1]] =
     Gen.oneOf(
       Arbitrary.arbitrary[List[Char]].map { cs =>
-        GenT(Parser.charIn(cs))
+        GenT(Parser0.charIn(cs))
       },
-      Gen.const(GenT(Parser.anyChar))
+      Gen.const(GenT(Parser0.anyChar))
     )
 
   val expect1: Gen[GenT[Parser1]] =
     Arbitrary.arbitrary[String].map { str =>
-      if (str.isEmpty) GenT(Parser.fail: Parser1[Unit])
-      else GenT(Parser.string1(str))
+      if (str.isEmpty) GenT(Parser0.fail: Parser1[Unit])
+      else GenT(Parser0.string1(str))
     }
 
   val ignoreCase1: Gen[GenT[Parser1]] =
     Arbitrary.arbitrary[String].map { str =>
-      if (str.isEmpty) GenT(Parser.fail: Parser1[Unit])
-      else GenT(Parser.ignoreCase1(str))
+      if (str.isEmpty) GenT(Parser0.fail: Parser1[Unit])
+      else GenT(Parser0.ignoreCase1(str))
     }
 
-  val fail: Gen[GenT[Parser]] =
-    Gen.const(GenT(Parser.fail: Parser[Unit]))
+  val fail: Gen[GenT[Parser0]] =
+    Gen.const(GenT(Parser0.fail: Parser0[Unit]))
 
-  val failWith: Gen[GenT[Parser]] =
+  val failWith: Gen[GenT[Parser0]] =
     Arbitrary.arbitrary[String].map { str =>
-      GenT(Parser.failWith[Unit](str))
+      GenT(Parser0.failWith[Unit](str))
     }
 
-  def void(g: GenT[Parser]): GenT[Parser] =
-    GenT(Parser.void(g.fa))
+  def void(g: GenT[Parser0]): GenT[Parser0] =
+    GenT(Parser0.void(g.fa))
 
   def void1(g: GenT[Parser1]): GenT[Parser1] =
-    GenT(Parser.void1(g.fa))
+    GenT(Parser0.void1(g.fa))
 
-  def string(g: GenT[Parser]): GenT[Parser] =
-    GenT(Parser.string(g.fa))
+  def string(g: GenT[Parser0]): GenT[Parser0] =
+    GenT(Parser0.string(g.fa))
 
   def string1(g: GenT[Parser1]): GenT[Parser1] =
-    GenT(Parser.string1(g.fa))
+    GenT(Parser0.string1(g.fa))
 
-  def backtrack(g: GenT[Parser]): GenT[Parser] =
+  def backtrack(g: GenT[Parser0]): GenT[Parser0] =
     GenT(g.fa.backtrack)(g.cogen)
 
   def backtrack1(g: GenT[Parser1]): GenT[Parser1] =
     GenT(g.fa.backtrack)(g.cogen)
 
-  def defer(g: GenT[Parser]): GenT[Parser] =
-    GenT(Defer[Parser].defer(g.fa))(g.cogen)
+  def defer(g: GenT[Parser0]): GenT[Parser0] =
+    GenT(Defer[Parser0].defer(g.fa))(g.cogen)
 
   def defer1(g: GenT[Parser1]): GenT[Parser1] =
     GenT(Defer[Parser1].defer(g.fa))(g.cogen)
 
-  def rep(g: GenT[Parser1]): GenT[Parser] = {
+  def rep(g: GenT[Parser1]): GenT[Parser0] = {
     implicit val cg = g.cogen
-    GenT[Parser, List[g.A]](g.fa.rep)
+    GenT[Parser0, List[g.A]](g.fa.rep)
   }
 
   def rep1(g: GenT[Parser1]): GenT[Parser1] = {
@@ -154,22 +154,22 @@ object ParserGen {
     GenT[Parser1, List[g.A]](g.fa.rep1.map(_.toList))
   }
 
-  def product(ga: GenT[Parser], gb: GenT[Parser]): Gen[GenT[Parser]] = {
+  def product(ga: GenT[Parser0], gb: GenT[Parser0]): Gen[GenT[Parser0]] = {
     implicit val ca: Cogen[ga.A] = ga.cogen
     implicit val cb: Cogen[gb.A] = gb.cogen
     Gen.oneOf(
-      GenT[Parser, (ga.A, gb.A)](FlatMap[Parser].product(ga.fa, gb.fa)),
-      GenT[Parser, (ga.A, gb.A)](FlatMap[Parser].map2(ga.fa, gb.fa)((_, _))),
-      GenT[Parser, (ga.A, gb.A)](FlatMap[Parser].map2Eval(ga.fa, Eval.later(gb.fa))((_, _)).value),
-      GenT[Parser, (ga.A, gb.A)](FlatMap[Parser].map2Eval(ga.fa, Eval.now(gb.fa))((_, _)).value)
+      GenT[Parser0, (ga.A, gb.A)](FlatMap[Parser0].product(ga.fa, gb.fa)),
+      GenT[Parser0, (ga.A, gb.A)](FlatMap[Parser0].map2(ga.fa, gb.fa)((_, _))),
+      GenT[Parser0, (ga.A, gb.A)](FlatMap[Parser0].map2Eval(ga.fa, Eval.later(gb.fa))((_, _)).value),
+      GenT[Parser0, (ga.A, gb.A)](FlatMap[Parser0].map2Eval(ga.fa, Eval.now(gb.fa))((_, _)).value)
     )
   }
 
-  def softProduct(ga: GenT[Parser], gb: GenT[Parser]): Gen[GenT[Parser]] = {
+  def softProduct(ga: GenT[Parser0], gb: GenT[Parser0]): Gen[GenT[Parser0]] = {
     implicit val ca: Cogen[ga.A] = ga.cogen
     implicit val cb: Cogen[gb.A] = gb.cogen
     Gen.const(
-      GenT[Parser, (ga.A, gb.A)](ga.fa.soft ~ gb.fa)
+      GenT[Parser0, (ga.A, gb.A)](ga.fa.soft ~ gb.fa)
     )
   }
 
@@ -186,18 +186,18 @@ object ParserGen {
     )
   }
 
-  def product10(ga: GenT[Parser1], gb: GenT[Parser]): Gen[GenT[Parser1]] = {
+  def product10(ga: GenT[Parser1], gb: GenT[Parser0]): Gen[GenT[Parser1]] = {
     implicit val ca: Cogen[ga.A] = ga.cogen
     implicit val cb: Cogen[gb.A] = gb.cogen
     Gen.oneOf(
-      GenT[Parser1, (ga.A, gb.A)](Parser.product10(ga.fa, gb.fa)),
+      GenT[Parser1, (ga.A, gb.A)](Parser0.product10(ga.fa, gb.fa)),
       GenT[Parser1, ga.A](ga.fa <* gb.fa),
       GenT[Parser1, gb.A](ga.fa *> gb.fa),
-      GenT[Parser1, (ga.A, ga.A)](Parser.product10(ga.fa, ga.fa))
+      GenT[Parser1, (ga.A, ga.A)](Parser0.product10(ga.fa, ga.fa))
     )
   }
 
-  def softProduct1(ga: GenT[Parser1], gb: GenT[Parser]): Gen[GenT[Parser1]] = {
+  def softProduct1(ga: GenT[Parser1], gb: GenT[Parser0]): Gen[GenT[Parser1]] = {
     implicit val ca: Cogen[ga.A] = ga.cogen
     implicit val cb: Cogen[gb.A] = gb.cogen
     Gen.oneOf(
@@ -210,7 +210,7 @@ object ParserGen {
     )
   }
 
-  def mapped(ga: GenT[Parser]): Gen[GenT[Parser]] = {
+  def mapped(ga: GenT[Parser0]): Gen[GenT[Parser0]] = {
     pures.flatMap { genRes =>
       implicit val ca: Cogen[ga.A] = ga.cogen
       implicit val cb: Cogen[genRes.A] = genRes.cogen
@@ -218,7 +218,7 @@ object ParserGen {
       fnGen.flatMap { fn =>
         Gen.oneOf(
           GenT(ga.fa.map(fn)),
-          GenT(FlatMap[Parser].map(ga.fa)(fn))
+          GenT(FlatMap[Parser0].map(ga.fa)(fn))
         )
       }
     }
@@ -244,9 +244,9 @@ object ParserGen {
     val fn: A => F[B]
   }
 
-  def selected(ga: Gen[GenT[Parser]]): Gen[GenT[Parser]] =
+  def selected(ga: Gen[GenT[Parser0]]): Gen[GenT[Parser0]] =
     Gen.zip(pures, pures).flatMap { case (genRes1, genRes2) =>
-      val genPR: Gen[Parser[Either[genRes1.A, genRes2.A]]] = {
+      val genPR: Gen[Parser0[Either[genRes1.A, genRes2.A]]] = {
         ga.flatMap { init =>
           val mapFn: Gen[init.A => Either[genRes1.A, genRes2.A]] =
             Gen.function1(Gen.either(genRes1.fa, genRes2.fa))(init.cogen)
@@ -256,7 +256,7 @@ object ParserGen {
         }
       }
 
-      val gfn: Gen[Parser[genRes1.A => genRes2.A]] =
+      val gfn: Gen[Parser0[genRes1.A => genRes2.A]] =
         ga.flatMap { init =>
           val mapFn: Gen[init.A => (genRes1.A => genRes2.A)] =
             Gen.function1(Gen.function1(genRes2.fa)(genRes1.cogen))(init.cogen)
@@ -266,13 +266,13 @@ object ParserGen {
         }
 
       Gen.zip(genPR, gfn).map { case (pab, fn) =>
-        GenT(Parser.select(pab)(fn))(genRes2.cogen)
+        GenT(Parser0.select(pab)(fn))(genRes2.cogen)
       }
     }
 
-  def flatMapped(ga: Gen[GenT[Parser]]): Gen[GenT[Parser]] =
+  def flatMapped(ga: Gen[GenT[Parser0]]): Gen[GenT[Parser0]] =
     Gen.zip(ga, pures).flatMap { case (parser, genRes) =>
-      val genPR: Gen[Parser[genRes.A]] = {
+      val genPR: Gen[Parser0[genRes.A]] = {
         ga.flatMap { init =>
           val mapFn: Gen[init.A => genRes.A] =
             Gen.function1(genRes.fa)(init.cogen)
@@ -283,21 +283,21 @@ object ParserGen {
         }
       }
 
-      val gfn: Gen[parser.A => Parser[genRes.A]] =
+      val gfn: Gen[parser.A => Parser0[genRes.A]] =
         Gen.function1(genPR)(parser.cogen)
 
       gfn.flatMap { fn =>
         Gen.oneOf(
           GenT(parser.fa.flatMap(fn))(genRes.cogen),
-          GenT(FlatMap[Parser].flatMap(parser.fa)(fn))(genRes.cogen)
+          GenT(FlatMap[Parser0].flatMap(parser.fa)(fn))(genRes.cogen)
         )
       }
     }
 
-  // if we use a Parser here, we could loop forever parsing nothing
-  def tailRecM(ga: Gen[GenT[Parser1]]): Gen[GenT[Parser]] =
+  // if we use a Parser0 here, we could loop forever parsing nothing
+  def tailRecM(ga: Gen[GenT[Parser1]]): Gen[GenT[Parser0]] =
     Gen.zip(pures, pures).flatMap { case (genRes1, genRes2) =>
-      val genPR: Gen[Parser[Either[genRes1.A, genRes2.A]]] = {
+      val genPR: Gen[Parser0[Either[genRes1.A, genRes2.A]]] = {
         ga.flatMap { init =>
           val mapFn: Gen[init.A => Either[genRes1.A, genRes2.A]] =
             Gen.function1(Gen.either(genRes1.fa, genRes2.fa))(init.cogen)
@@ -313,7 +313,7 @@ object ParserGen {
       Gen
         .zip(genRes1.fa, gfn)
         .map { case (init, fn) =>
-          GenT(Monad[Parser].tailRecM(init)(fn))(genRes2.cogen)
+          GenT(Monad[Parser0].tailRecM(init)(fn))(genRes2.cogen)
         }
     }
 
@@ -339,7 +339,7 @@ object ParserGen {
         }
     }
 
-  def selected1(ga1: Gen[GenT[Parser1]], ga0: Gen[GenT[Parser]]): Gen[GenT[Parser1]] =
+  def selected1(ga1: Gen[GenT[Parser1]], ga0: Gen[GenT[Parser0]]): Gen[GenT[Parser1]] =
     Gen.zip(pures, pures).flatMap { case (genRes1, genRes2) =>
       val genPR1: Gen[Parser1[Either[genRes1.A, genRes2.A]]] = {
         ga1.flatMap { init =>
@@ -351,7 +351,7 @@ object ParserGen {
         }
       }
 
-      val gfn: Gen[Parser[genRes1.A => genRes2.A]] =
+      val gfn: Gen[Parser0[genRes1.A => genRes2.A]] =
         ga0.flatMap { init =>
           val mapFn: Gen[init.A => (genRes1.A => genRes2.A)] =
             Gen.function1(Gen.function1(genRes2.fa)(genRes1.cogen))(init.cogen)
@@ -361,11 +361,11 @@ object ParserGen {
         }
 
       Gen.zip(genPR1, gfn).map { case (pab, fn) =>
-        GenT(Parser.select1(pab)(fn))(genRes2.cogen)
+        GenT(Parser0.select1(pab)(fn))(genRes2.cogen)
       }
     }
 
-  def flatMapped1(ga: Gen[GenT[Parser]], ga1: Gen[GenT[Parser1]]): Gen[GenT[Parser1]] =
+  def flatMapped1(ga: Gen[GenT[Parser0]], ga1: Gen[GenT[Parser1]]): Gen[GenT[Parser1]] =
     Gen.zip(ga, ga1, pures).flatMap { case (parser, parser1, genRes) =>
       val genPR: Gen[Parser1[genRes.A]] = {
         ga1.flatMap { init =>
@@ -403,7 +403,7 @@ object ParserGen {
       )
     }
 
-  def orElse(ga: GenT[Parser], gb: GenT[Parser], res: GenT[Gen]): Gen[GenT[Parser]] = {
+  def orElse(ga: GenT[Parser0], gb: GenT[Parser0], res: GenT[Gen]): Gen[GenT[Parser0]] = {
     val genFn1: Gen[ga.A => res.A] = Gen.function1(res.fa)(ga.cogen)
     val genFn2: Gen[gb.A => res.A] = Gen.function1(res.fa)(gb.cogen)
     implicit val cogenResA: Cogen[res.A] = res.cogen
@@ -411,7 +411,7 @@ object ParserGen {
     Gen.zip(genFn1, genFn2).flatMap { case (f1, f2) =>
       Gen.oneOf(
         GenT(ga.fa.map(f1).orElse(gb.fa.map(f2))),
-        GenT(MonoidK[Parser].combineK(ga.fa.map(f1), gb.fa.map(f2)))
+        GenT(MonoidK[Parser0].combineK(ga.fa.map(f1), gb.fa.map(f2)))
       )
     }
   }
@@ -430,7 +430,7 @@ object ParserGen {
   }
 
   // Generate a random parser
-  lazy val gen: Gen[GenT[Parser]] = {
+  lazy val gen: Gen[GenT[Parser0]] = {
     val rec = Gen.lzy(gen)
 
     Gen.frequency(
@@ -438,14 +438,14 @@ object ParserGen {
         3,
         pures
           .flatMap(_.toId)
-          .map(_.transform(new FunctionK[Id, Parser] {
-            def apply[A](g: Id[A]): Parser[A] = Parser.pure(g)
+          .map(_.transform(new FunctionK[Id, Parser0] {
+            def apply[A](g: Id[A]): Parser0[A] = Parser0.pure(g)
           }))
       ),
       (5, expect0),
       (1, ignoreCase),
       (5, charIn),
-      (1, Gen.oneOf(GenT(Parser.start), GenT(Parser.end), GenT(Parser.index))),
+      (1, Gen.oneOf(GenT(Parser0.start), GenT(Parser0.end), GenT(Parser0.index))),
       (1, fail),
       (1, failWith),
       (1, rec.map(void(_))),
@@ -457,7 +457,7 @@ object ParserGen {
       (1, rec.flatMap(mapped(_))),
       (1, rec.flatMap(selected(_))),
       (1, tailRecM(Gen.lzy(gen1))),
-      (1, Gen.choose(0, 10).map { l => GenT(Parser.length(l)) }),
+      (1, Gen.choose(0, 10).map { l => GenT(Parser0.length(l)) }),
       (1, flatMapped(rec)),
       (1, Gen.zip(rec, rec).flatMap { case (g1, g2) => product(g1, g2) }),
       (1, Gen.zip(rec, rec).flatMap { case (g1, g2) => softProduct(g1, g2) }),
@@ -473,7 +473,7 @@ object ParserGen {
       (8, expect1),
       (2, ignoreCase1),
       (8, charIn1),
-      (1, Gen.choose(Char.MinValue, Char.MaxValue).map { c => GenT(Parser.char(c)) }),
+      (1, Gen.choose(Char.MinValue, Char.MaxValue).map { c => GenT(Parser0.char(c)) }),
       (2, rec.map(void1(_))),
       (2, rec.map(string1(_))),
       (2, rec.map(backtrack1(_))),
@@ -483,7 +483,7 @@ object ParserGen {
       (1, rec.flatMap(mapped1(_))),
       (1, flatMapped1(gen, rec)),
       (1, tailRecM1(rec)),
-      (1, Gen.choose(1, 10).map { l => GenT(Parser.length1(l)) }),
+      (1, Gen.choose(1, 10).map { l => GenT(Parser0.length1(l)) }),
       (
         2,
         Gen.frequency(
@@ -496,7 +496,7 @@ object ParserGen {
     )
   }
 
-  def genParser[A](genA: Gen[A]): Gen[Parser[A]] =
+  def genParser0[A](genA: Gen[A]): Gen[Parser0[A]] =
     for {
       genT <- gen
       fn <- Gen.function1(genA)(genT.cogen)
@@ -508,8 +508,8 @@ object ParserGen {
       fn <- Gen.function1(genA)(genT.cogen)
     } yield genT.fa.map(fn)
 
-  implicit def arbParser[A: Arbitrary]: Arbitrary[Parser[A]] =
-    Arbitrary(genParser(Arbitrary.arbitrary[A]))
+  implicit def arbParser0[A: Arbitrary]: Arbitrary[Parser0[A]] =
+    Arbitrary(genParser0(Arbitrary.arbitrary[A]))
 
   implicit def arbParser1[A: Arbitrary]: Arbitrary[Parser1[A]] =
     Arbitrary(genParser1(Arbitrary.arbitrary[A]))
@@ -517,7 +517,7 @@ object ParserGen {
 
 class ParserTest extends munit.ScalaCheckSuite {
 
-  import ParserGen.{arbParser, arbParser1}
+  import ParserGen.{arbParser0, arbParser1}
 
   val tests: Int = if (BitSetUtil.isScalaJs) 50 else 2000
 
@@ -526,7 +526,7 @@ class ParserTest extends munit.ScalaCheckSuite {
       .withMinSuccessfulTests(tests)
       .withMaxDiscardRatio(10)
 
-  def parseTest[A: Eq](p: Parser[A], str: String, a: A) =
+  def parseTest[A: Eq](p: Parser0[A], str: String, a: A) =
     p.parse(str) match {
       case Right((_, res)) =>
         assert(Eq[A].eqv(a, res), s"expected: $a got $res")
@@ -534,7 +534,7 @@ class ParserTest extends munit.ScalaCheckSuite {
         assert(false, errs.toString)
     }
 
-  def parseFail[A: Eq](p: Parser[A], str: String) =
+  def parseFail[A: Eq](p: Parser0[A], str: String) =
     p.parse(str) match {
       case Right(res) =>
         assert(false, s"expected to not parse, but found: $res")
@@ -543,15 +543,15 @@ class ParserTest extends munit.ScalaCheckSuite {
     }
 
   test("pure works") {
-    parseTest(Parser.pure(42), "anything", 42)
+    parseTest(Parser0.pure(42), "anything", 42)
   }
 
-  val fooP = Parser.string1("foo")
-  val barP = Parser.string1("bar")
-  val fooCIP = Parser.ignoreCase1("foo")
-  val cCIP = Parser.ignoreCase1("a")
-  val cCIP1 = Parser.ignoreCaseChar('a')
-  val abcCI = Parser.ignoreCaseCharIn('a', 'b', 'c')
+  val fooP = Parser0.string1("foo")
+  val barP = Parser0.string1("bar")
+  val fooCIP = Parser0.ignoreCase1("foo")
+  val cCIP = Parser0.ignoreCase1("a")
+  val cCIP1 = Parser0.ignoreCaseChar('a')
+  val abcCI = Parser0.ignoreCaseCharIn('a', 'b', 'c')
 
   test("string tests") {
     parseTest(fooP, "foobar", ())
@@ -571,17 +571,17 @@ class ParserTest extends munit.ScalaCheckSuite {
     parseTest(abcCI, "C", 'C')
     parseFail(abcCI, "D")
 
-    parseTest(Parser.oneOf1(fooP :: barP :: Nil), "bar", ())
-    parseTest(Parser.oneOf1(fooP :: barP :: Nil), "foo", ())
+    parseTest(Parser0.oneOf1(fooP :: barP :: Nil), "bar", ())
+    parseTest(Parser0.oneOf1(fooP :: barP :: Nil), "foo", ())
   }
 
   test("product tests") {
-    parseTest(Parser.product01(fooP, barP), "foobar", ((), ()))
-    parseTest(Parser.product10(fooP, barP), "foobar", ((), ()))
-    parseTest(Parser.product(fooP, barP), "foobar", ((), ()))
+    parseTest(Parser0.product01(fooP, barP), "foobar", ((), ()))
+    parseTest(Parser0.product10(fooP, barP), "foobar", ((), ()))
+    parseTest(Parser0.product(fooP, barP), "foobar", ((), ()))
   }
 
-  property("Parser on success replaces parsed value") {
+  property("Parser0 on success replaces parsed value") {
     forAll(ParserGen.gen, Arbitrary.arbitrary[String]) { (genP, str) =>
       val res0 = genP.fa.as("something").parse(str)
       res0 match {
@@ -591,19 +591,19 @@ class ParserTest extends munit.ScalaCheckSuite {
     }
   }
 
-  property("Parser.start and end work") {
+  property("Parser0.start and end work") {
     forAll { (s: String) =>
       if (s.isEmpty) {
         intercept[IllegalArgumentException] {
-          Parser.string1(s)
+          Parser0.string1(s)
         }
       } else {
-        val pa = Parser.string1(s)
-        assertEquals((Parser.start ~ pa ~ Parser.end).void.parse(s), Right(("", ())))
-        assert((pa ~ Parser.start).parse(s).isLeft)
-        assert((Parser.end ~ pa).parse(s).isLeft)
+        val pa = Parser0.string1(s)
+        assertEquals((Parser0.start ~ pa ~ Parser0.end).void.parse(s), Right(("", ())))
+        assert((pa ~ Parser0.start).parse(s).isLeft)
+        assert((Parser0.end ~ pa).parse(s).isLeft)
         assertEquals(
-          (Parser.index ~ pa ~ Parser.index).map { case ((s, _), e) => e - s }.parse(s),
+          (Parser0.index ~ pa ~ Parser0.index).map { case ((s, _), e) => e - s }.parse(s),
           Right(("", s.length))
         )
       }
@@ -612,16 +612,16 @@ class ParserTest extends munit.ScalaCheckSuite {
     }
   }
 
-  property("Parser.length succeeds when the string is long enough") {
+  property("Parser0.length succeeds when the string is long enough") {
     forAll { (s: String, len: Int) =>
       if (len < 1) {
         intercept[IllegalArgumentException] {
-          Parser.length1(len)
+          Parser0.length1(len)
         }
-        assertEquals(Parser.length(len).parse(s), Right((s, "")))
+        assertEquals(Parser0.length(len).parse(s), Right((s, "")))
       } else {
-        val pa = Parser.length(len)
-        val pa1 = Parser.length1(len)
+        val pa = Parser0.length(len)
+        val pa1 = Parser0.length1(len)
 
         val res = pa.parse(s)
         val res1 = pa1.parse(s)
@@ -634,7 +634,7 @@ class ParserTest extends munit.ScalaCheckSuite {
               assertEquals(s.take(len), first)
               assertEquals(s.drop(len), rest)
             } else fail(s"expected to not parse: $rest, $first")
-          case Left(Parser.Error(0, NonEmptyList(Parser.Expectation.Length(off, l, a), Nil))) =>
+          case Left(Parser0.Error(0, NonEmptyList(Parser0.Expectation.Length(off, l, a), Nil))) =>
             assertEquals(off, 0)
             assertEquals(l, len)
             assertEquals(a, s.length)
@@ -651,7 +651,7 @@ class ParserTest extends munit.ScalaCheckSuite {
     forAll(ParserGen.gen, Arbitrary.arbitrary[String]) { (genP, str) =>
       val r1 = genP.fa.parse(str)
       val r2 = genP.fa.void.parse(str)
-      val r3 = FlatMap[Parser].void(genP.fa).parse(str)
+      val r3 = FlatMap[Parser0].void(genP.fa).parse(str)
       val r4 = genP.fa.as(()).parse(str)
 
       assertEquals(r2, r1.map { case (off, _) => (off, ()) })
@@ -666,7 +666,7 @@ class ParserTest extends munit.ScalaCheckSuite {
       val r2 = genP.fa.void.parse(str)
       val r3 = FlatMap[Parser1].void(genP.fa).parse(str)
       val r4 = genP.fa.as(()).parse(str)
-      val r5 = ((genP.fa.void: Parser[Unit]) <* Monad[Parser].unit).parse(str)
+      val r5 = ((genP.fa.void: Parser0[Unit]) <* Monad[Parser0].unit).parse(str)
 
       assertEquals(r2, r1.map { case (off, _) => (off, ()) })
       assertEquals(r2, r3)
@@ -691,8 +691,8 @@ class ParserTest extends munit.ScalaCheckSuite {
   property("oneOf nesting doesn't change results") {
     forAll(Gen.listOf(ParserGen.gen), Gen.listOf(ParserGen.gen), Arbitrary.arbitrary[String]) {
       (genP1, genP2, str) =>
-        val oneOf1 = Parser.oneOf((genP1 ::: genP2).map(_.fa))
-        val oneOf2 = Parser.oneOf(genP1.map(_.fa)).orElse(Parser.oneOf(genP2.map(_.fa)))
+        val oneOf1 = Parser0.oneOf((genP1 ::: genP2).map(_.fa))
+        val oneOf2 = Parser0.oneOf(genP1.map(_.fa)).orElse(Parser0.oneOf(genP2.map(_.fa)))
 
         assertEquals(oneOf1.parse(str), oneOf2.parse(str))
     }
@@ -701,20 +701,20 @@ class ParserTest extends munit.ScalaCheckSuite {
   property("oneOf1 nesting doesn't change results") {
     forAll(Gen.listOf(ParserGen.gen1), Gen.listOf(ParserGen.gen1), Arbitrary.arbitrary[String]) {
       (genP1, genP2, str) =>
-        val oneOf1 = Parser.oneOf1((genP1 ::: genP2).map(_.fa))
-        val oneOf2 = Parser
+        val oneOf1 = Parser0.oneOf1((genP1 ::: genP2).map(_.fa))
+        val oneOf2 = Parser0
           .oneOf1(genP1.map(_.fa))
           .orElse1(
-            Parser.oneOf1(genP2.map(_.fa))
+            Parser0.oneOf1(genP2.map(_.fa))
           )
 
         assertEquals(oneOf1.parse(str), oneOf2.parse(str))
     }
   }
 
-  def orElse[A](p1: Parser[A], p2: Parser[A], str: String): Either[Parser.Error, (String, A)] = {
-    if (p1 == Parser.Fail) p2.parse(str)
-    else if (p2 == Parser.Fail) p1.parse(str)
+  def orElse[A](p1: Parser0[A], p2: Parser0[A], str: String): Either[Parser0.Error, (String, A)] = {
+    if (p1 == Parser0.Fail) p2.parse(str)
+    else if (p2 == Parser0.Fail) p1.parse(str)
     else
       p1.parse(str) match {
         case left @ Left(err) =>
@@ -723,7 +723,7 @@ class ParserTest extends munit.ScalaCheckSuite {
               .leftMap { err1 =>
                 if (err1.failedAtOffset == 0) {
                   val errs = err.expected ::: err1.expected
-                  Parser.Error(err1.failedAtOffset, Parser.Expectation.unify(errs))
+                  Parser0.Error(err1.failedAtOffset, Parser0.Expectation.unify(errs))
                 } else err1
               }
           } else left
@@ -745,24 +745,24 @@ class ParserTest extends munit.ScalaCheckSuite {
 
   property("oneOf same as foldLeft(fail)(_.orElse(_))") {
     forAll(Gen.listOf(ParserGen.gen), Arbitrary.arbitrary[String]) { (genP1, str) =>
-      val oneOfImpl = genP1.foldLeft(Parser.fail: Parser[Any]) { (leftp, p) => leftp.orElse(p.fa) }
+      val oneOfImpl = genP1.foldLeft(Parser0.fail: Parser0[Any]) { (leftp, p) => leftp.orElse(p.fa) }
 
-      assertEquals(oneOfImpl.parse(str), Parser.oneOf(genP1.map(_.fa)).parse(str))
+      assertEquals(oneOfImpl.parse(str), Parser0.oneOf(genP1.map(_.fa)).parse(str))
     }
   }
 
   property("oneOf1 same as foldLeft(fail)(_.orElse1(_))") {
     forAll(Gen.listOf(ParserGen.gen1), Arbitrary.arbitrary[String]) { (genP1, str) =>
-      val oneOfImpl = genP1.foldLeft(Parser.fail[Any]) { (leftp, p) => leftp.orElse1(p.fa) }
+      val oneOfImpl = genP1.foldLeft(Parser0.fail[Any]) { (leftp, p) => leftp.orElse1(p.fa) }
 
-      assertEquals(oneOfImpl.parse(str), Parser.oneOf1(genP1.map(_.fa)).parse(str))
+      assertEquals(oneOfImpl.parse(str), Parser0.oneOf1(genP1.map(_.fa)).parse(str))
     }
   }
 
   property("string can be recovered with index") {
     forAll(ParserGen.gen, Arbitrary.arbitrary[String]) { (genP, str) =>
       val r1 = genP.fa.string.parse(str)
-      val r2 = (genP.fa ~ Parser.index).map { case (_, end) => str.substring(0, end) }.parse(str)
+      val r2 = (genP.fa ~ Parser0.index).map { case (_, end) => str.substring(0, end) }.parse(str)
 
       assertEquals(r1.toOption, r2.toOption)
     }
@@ -770,7 +770,7 @@ class ParserTest extends munit.ScalaCheckSuite {
 
   property("backtrack orElse pure always succeeds") {
     forAll(ParserGen.gen, Arbitrary.arbitrary[String]) { (genP, str) =>
-      val p1 = genP.fa.backtrack.orElse(Parser.pure(())): Parser[Any]
+      val p1 = genP.fa.backtrack.orElse(Parser0.pure(())): Parser0[Any]
 
       assert(p1.parse(str).isRight)
     }
@@ -798,7 +798,7 @@ class ParserTest extends munit.ScalaCheckSuite {
       val composed = p1.fa ~ p2.fa
       val cres = composed.parse(str)
 
-      val composed1 = Monad[Parser].product(p1.fa, p2.fa)
+      val composed1 = Monad[Parser0].product(p1.fa, p2.fa)
       composed1.parse(str)
 
       val sequence =
@@ -808,7 +808,7 @@ class ParserTest extends munit.ScalaCheckSuite {
           off = if (s1 == "") str.length else str.indexOf(s1)
           // make the offsets the same
           sfix = " " * off + s1
-          p3 = (Parser.length(off) ~ p2.fa).map(_._2)
+          p3 = (Parser0.length(off) ~ p2.fa).map(_._2)
           pair2 <- p3.parse(sfix)
           (s2, a2) = pair2
         } yield (s2, (a1, a2))
@@ -822,7 +822,7 @@ class ParserTest extends munit.ScalaCheckSuite {
       val composed = p1.fa ~ p2.fa
       val cres = composed.parse(str)
 
-      val composed1 = FlatMap[Parser].product(p1.fa, p2.fa)
+      val composed1 = FlatMap[Parser0].product(p1.fa, p2.fa)
       val cres1 = composed1.parse(str)
       assertEquals(cres, cres1)
 
@@ -833,7 +833,7 @@ class ParserTest extends munit.ScalaCheckSuite {
           off = if (s1 == "") str.length else str.indexOf(s1)
           // make the offsets the same
           sfix = " " * off + s1
-          p3 = Parser.length(off) *> p2.fa
+          p3 = Parser0.length(off) *> p2.fa
           pair2 <- p3.parse(sfix)
           (s2, a2) = pair2
         } yield (s2, (a1, a2))
@@ -854,7 +854,7 @@ class ParserTest extends munit.ScalaCheckSuite {
           off = if (s1 == "") str.length else str.indexOf(s1)
           // make the offsets the same
           sfix = " " * off + s1
-          p3 = Parser.length(off) *> p2.fa
+          p3 = Parser0.length(off) *> p2.fa
           pair2 <- p3.parse(sfix)
           (s2, a2) = pair2
         } yield (s2, (a1, a2))
@@ -875,9 +875,9 @@ class ParserTest extends munit.ScalaCheckSuite {
           off = if (s1 == "") str.length else str.indexOf(s1)
           // make the offsets the same
           sfix = " " * off + s1
-          p3 = (Parser.length(off) ~ p2.fa).map(_._2)
+          p3 = (Parser0.length(off) ~ p2.fa).map(_._2)
           pair2 <- (p3.parse(sfix).leftMap {
-            case Parser.Error(fidx, errs) if (fidx == off) => Parser.Error(0, errs)
+            case Parser0.Error(fidx, errs) if (fidx == off) => Parser0.Error(0, errs)
             case notEps2 => notEps2
           })
           (s2, a2) = pair2
@@ -899,9 +899,9 @@ class ParserTest extends munit.ScalaCheckSuite {
           off = if (s1 == "") str.length else str.indexOf(s1)
           // make the offsets the same
           sfix = " " * off + s1
-          p3 = (Parser.length(off) ~ p2.fa).map(_._2)
+          p3 = (Parser0.length(off) ~ p2.fa).map(_._2)
           pair2 <- (p3.parse(sfix).leftMap {
-            case Parser.Error(fidx, errs) if (fidx == off) => Parser.Error(0, errs)
+            case Parser0.Error(fidx, errs) if (fidx == off) => Parser0.Error(0, errs)
             case notEps2 => notEps2
           })
           (s2, a2) = pair2
@@ -923,9 +923,9 @@ class ParserTest extends munit.ScalaCheckSuite {
           off = if (s1 == "") str.length else str.indexOf(s1)
           // make the offsets the same
           sfix = " " * off + s1
-          p3 = (Parser.length(off) ~ p2.fa).map(_._2)
+          p3 = (Parser0.length(off) ~ p2.fa).map(_._2)
           pair2 <- (p3.parse(sfix).leftMap {
-            case Parser.Error(fidx, errs) if (fidx == off) => Parser.Error(0, errs)
+            case Parser0.Error(fidx, errs) if (fidx == off) => Parser0.Error(0, errs)
             case notEps2 => notEps2
           })
           (s2, a2) = pair2
@@ -936,16 +936,16 @@ class ParserTest extends munit.ScalaCheckSuite {
   }
 
   test("range messages seem to work") {
-    val pa = Parser.charIn('0' to '9')
+    val pa = Parser0.charIn('0' to '9')
     assertEquals(pa.parse("z").toString, "Left(Error(0,NonEmptyList(InRange(0,0,9))))")
   }
 
   test("partial parse fails in rep") {
-    val partial = Parser.length1(1) ~ Parser.fail
+    val partial = Parser0.length1(1) ~ Parser0.fail
     // we can't return empty list here
     assert(partial.rep.parse("foo").isLeft)
 
-    val p2 = Parser.string1("f").orElse1((Parser.string1("boo") ~ Parser.string1("p")).void)
+    val p2 = Parser0.string1("f").orElse1((Parser0.string1("boo") ~ Parser0.string1("p")).void)
     assert(p2.rep1.parse("fboop").isRight)
     assert(p2.rep1(2).parse("fboop").isRight)
     assert(p2.rep1(3).parse("fboop").isLeft)
@@ -954,9 +954,9 @@ class ParserTest extends munit.ScalaCheckSuite {
 
   test("defer does not run eagerly") {
     var cnt = 0
-    val res = Defer[Parser].defer {
+    val res = Defer[Parser0].defer {
       cnt += 1
-      Parser.string1("foo")
+      Parser0.string1("foo")
     }
     assert(cnt == 0)
     assert(res.parse("foo") == Right(("", ())))
@@ -969,7 +969,7 @@ class ParserTest extends munit.ScalaCheckSuite {
     var cnt = 0
     val res = Defer[Parser1].defer {
       cnt += 1
-      Parser.string1("foo")
+      Parser0.string1("foo")
     }
     assert(cnt == 0)
     assert(res.parse("foo") == Right(("", ())))
@@ -981,8 +981,8 @@ class ParserTest extends munit.ScalaCheckSuite {
   property("charIn matches charWhere") {
     forAll { (cs: List[Char], str: String) =>
       val cset = cs.toSet
-      val p1 = Parser.charIn(cs)
-      val p2 = Parser.charWhere(cset)
+      val p1 = Parser0.charIn(cs)
+      val p2 = Parser0.charWhere(cset)
 
       assertEquals(p1.parse(str), p2.parse(str))
     }
@@ -991,20 +991,20 @@ class ParserTest extends munit.ScalaCheckSuite {
   property("charIn matches charIn varargs") {
     forAll { (c0: Char, cs0: List[Char], str: String) =>
       val cs = c0 :: cs0
-      val p1 = Parser.charIn(cs)
-      val p2 = Parser.charIn(c0, cs0: _*)
+      val p1 = Parser0.charIn(cs)
+      val p2 = Parser0.charIn(c0, cs0: _*)
 
       assertEquals(p1.parse(str), p2.parse(str))
     }
   }
 
-  property("Parser.end gives the right error") {
+  property("Parser0.end gives the right error") {
     forAll { (str: String) =>
-      Parser.end.parse(str) match {
+      Parser0.end.parse(str) match {
         case Right((rest, _)) =>
           assertEquals(str, "")
           assertEquals(rest, "")
-        case Left(Parser.Error(0, NonEmptyList(Parser.Expectation.EndOfString(off, len), Nil))) =>
+        case Left(Parser0.Error(0, NonEmptyList(Parser0.Expectation.EndOfString(off, len), Nil))) =>
           assertEquals(off, 0)
           assertEquals(len, str.length)
         case other =>
@@ -1015,11 +1015,11 @@ class ParserTest extends munit.ScalaCheckSuite {
 
   property("rep can be reimplemented with oneOf and defer") {
     forAll(ParserGen.gen1, Arbitrary.arbitrary[String]) { (genP, str) =>
-      def rep[A](pa: Parser1[A]): Parser[List[A]] =
-        Defer[Parser].fix[List[A]] { tail =>
+      def rep[A](pa: Parser1[A]): Parser0[List[A]] =
+        Defer[Parser0].fix[List[A]] { tail =>
           (pa ~ tail)
             .map { case (h, t) => h :: t }
-            .orElse(Parser.pure(Nil))
+            .orElse(Parser0.pure(Nil))
         }
 
       val lst1 = rep(genP.fa)
@@ -1038,8 +1038,8 @@ class ParserTest extends munit.ScalaCheckSuite {
           .rep1(min)
           .map(_.toList)
           .orElse(
-            if (min == 0) Parser.pure(Nil)
-            else Parser.fail
+            if (min == 0) Parser0.pure(Nil)
+            else Parser0.fail
           )
 
         assertEquals(repA.parse(str), repB.parse(str))
@@ -1050,13 +1050,13 @@ class ParserTest extends munit.ScalaCheckSuite {
     forAll(ParserGen.gen1, Gen.choose(0, Int.MaxValue), Arbitrary.arbitrary[String]) {
       (genP, min0, str) =>
         val min = min0 & Int.MaxValue
-        val p1a = Parser.repSep(genP.fa, min = min, sep = Parser.unit)
+        val p1a = Parser0.repSep(genP.fa, min = min, sep = Parser0.unit)
         val p1b = genP.fa.rep(min = min)
 
         assertEquals(p1a.parse(str), p1b.parse(str))
 
         val min1 = if (min < 1) 1 else min
-        val p2a = Parser.rep1Sep(genP.fa, min = min1, sep = Parser.unit)
+        val p2a = Parser0.rep1Sep(genP.fa, min = min1, sep = Parser0.unit)
         val p2b = genP.fa.rep1(min = min1)
 
         assertEquals(p2a.parse(str), p2b.parse(str))
@@ -1067,7 +1067,7 @@ class ParserTest extends munit.ScalaCheckSuite {
     forAll(ParserGen.gen1, Arbitrary.arbitrary[String]) { (genP, str) =>
       assertEquals(
         genP.fa.parse(str),
-        Parser.rep1Sep(genP.fa, 1, Parser.fail).parse(str).map { case (rest, nel) =>
+        Parser0.rep1Sep(genP.fa, 1, Parser0.fail).parse(str).map { case (rest, nel) =>
           (rest, nel.head)
         }
       )
@@ -1080,26 +1080,26 @@ class ParserTest extends munit.ScalaCheckSuite {
       Arbitrary.arbitrary[String]
     ) { (chars, str) =>
       val pred = chars.toSet
-      val p1a = Parser.charsWhile(pred)
-      val p1b = Parser.charWhere(pred).rep.string
+      val p1a = Parser0.charsWhile(pred)
+      val p1b = Parser0.charWhere(pred).rep.string
       assertEquals(p1a.parse(str), p1b.parse(str))
 
-      val p2a = Parser.charsWhile1(pred)
-      val p2b = Parser.charWhere(pred).rep1.string
+      val p2a = Parser0.charsWhile1(pred)
+      val p2b = Parser0.charWhere(pred).rep1.string
       assertEquals(p2a.parse(str), p2b.parse(str))
     }
   }
 
-  property("MonoidK[Parser].empty never succeeds") {
+  property("MonoidK[Parser0].empty never succeeds") {
     forAll { (str: String) =>
-      assert(MonoidK[Parser].empty.parse(str).isLeft)
+      assert(MonoidK[Parser0].empty.parse(str).isLeft)
       assert(MonoidK[Parser1].empty.parse(str).isLeft)
     }
   }
 
   property("Monad.pure is an identity function") {
     forAll { (i: Int, str: String) =>
-      assertEquals(Monad[Parser].pure(i).parse(str), Right((str, i)))
+      assertEquals(Monad[Parser0].pure(i).parse(str), Right((str, i)))
     }
   }
 
@@ -1154,7 +1154,7 @@ class ParserTest extends munit.ScalaCheckSuite {
   }
 
   test("charWhere(_ => true) == anyChar") {
-    assertEquals(Parser.charWhere(_ => true), Parser.anyChar)
+    assertEquals(Parser0.charWhere(_ => true), Parser0.anyChar)
   }
 
   property("with1 *> and with1 <* work as expected") {
@@ -1173,11 +1173,11 @@ class ParserTest extends munit.ScalaCheckSuite {
     forAll(ParserGen.gen1, ParserGen.gen, Arbitrary.arbitrary[String]) { (p1, p2, str) =>
       assertEquals(
         (p1.fa *> p2.fa).parse(str),
-        Parser.product10(p1.fa.void, p2.fa).map(_._2).parse(str)
+        Parser0.product10(p1.fa.void, p2.fa).map(_._2).parse(str)
       )
       assertEquals(
         (p1.fa <* p2.fa).parse(str),
-        Parser.product10(p1.fa, p2.fa.void).map(_._1).parse(str)
+        Parser0.product10(p1.fa, p2.fa.void).map(_._1).parse(str)
       )
     }
   }
@@ -1281,15 +1281,15 @@ class ParserTest extends munit.ScalaCheckSuite {
   property("(a.soft ~ b) == softProduct(a, b)") {
     forAll(ParserGen.gen, ParserGen.gen, Arbitrary.arbitrary[String]) { (a, b, str) =>
       val left = a.fa.soft ~ b.fa
-      val right = Parser.softProduct(a.fa, b.fa)
+      val right = Parser0.softProduct(a.fa, b.fa)
       assertEquals(left.parse(str), right.parse(str))
       assertEquals(
         (a.fa.soft *> b.fa).parse(str),
-        Parser.softProduct(a.fa.void, b.fa).map(_._2).parse(str)
+        Parser0.softProduct(a.fa.void, b.fa).map(_._2).parse(str)
       )
       assertEquals(
         (a.fa.soft <* b.fa).parse(str),
-        Parser.softProduct(a.fa, b.fa.void).map(_._1).parse(str)
+        Parser0.softProduct(a.fa, b.fa.void).map(_._1).parse(str)
       )
     }
   }
@@ -1297,33 +1297,33 @@ class ParserTest extends munit.ScalaCheckSuite {
   property("(a1.soft ~ b) == softProduct10(a, b)") {
     forAll(ParserGen.gen1, ParserGen.gen, Arbitrary.arbitrary[String]) { (a, b, str) =>
       val left1 = a.fa.soft ~ b.fa
-      val right1 = Parser.softProduct10(a.fa, b.fa)
+      val right1 = Parser0.softProduct10(a.fa, b.fa)
       assertEquals(left1.parse(str), right1.parse(str))
 
       val left2 = b.fa.soft ~ a.fa
-      val right2 = Parser.softProduct01(b.fa, a.fa)
+      val right2 = Parser0.softProduct01(b.fa, a.fa)
       assertEquals(left2.parse(str), right2.parse(str))
 
       assertEquals(
         (a.fa.soft *> b.fa).parse(str),
-        Parser.softProduct10(a.fa.void, b.fa).map(_._2).parse(str)
+        Parser0.softProduct10(a.fa.void, b.fa).map(_._2).parse(str)
       )
       assertEquals(
         (b.fa.with1.soft <* a.fa).parse(str),
-        Parser.softProduct01(b.fa, a.fa.void).map(_._1).parse(str)
+        Parser0.softProduct01(b.fa, a.fa.void).map(_._1).parse(str)
       )
       assertEquals(
         (b.fa.with1.soft *> a.fa).parse(str),
-        Parser.softProduct01(b.fa.void, a.fa).map(_._2).parse(str)
+        Parser0.softProduct01(b.fa.void, a.fa).map(_._2).parse(str)
       )
     }
   }
 
-  property("Parser.until is like a search") {
+  property("Parser0.until is like a search") {
     forAll(ParserGen.gen, Arbitrary.arbitrary[String]) { (a, str) =>
-      val p = Parser.until(a.fa) *> a.fa
+      val p = Parser0.until(a.fa) *> a.fa
       def loopMatch(cnt: Int): Option[(String, a.A)] =
-        (Parser.length(cnt) *> a.fa).parse(str) match {
+        (Parser0.length(cnt) *> a.fa).parse(str) match {
           case Right(res) => Some(res)
           case Left(_) if cnt > str.length => None
           case _ => loopMatch(cnt + 1)
@@ -1335,7 +1335,7 @@ class ParserTest extends munit.ScalaCheckSuite {
 
   property("parseAll law") {
     forAll(ParserGen.gen, Arbitrary.arbitrary[String]) { (a, str) =>
-      val pall = (a.fa <* Parser.end).parse(str).map(_._2)
+      val pall = (a.fa <* Parser0.end).parse(str).map(_._2)
 
       assertEquals(a.fa.parseAll(str), pall)
     }
@@ -1459,15 +1459,15 @@ class ParserTest extends munit.ScalaCheckSuite {
   property("failWith returns the given error message") {
     forAll { (str: String, mes: String) =>
       assertEquals(
-        Parser.failWith(mes).parse(str),
-        Left(Parser.Error(0, NonEmptyList.of(Parser.Expectation.FailWith(0, mes))))
+        Parser0.failWith(mes).parse(str),
+        Left(Parser0.Error(0, NonEmptyList.of(Parser0.Expectation.FailWith(0, mes))))
       )
     }
   }
 
   property("failWith.? returns None") {
     forAll { (str: String, mes: String) =>
-      assertEquals(Parser.failWith(mes).?.parse(str), Right((str, None)))
+      assertEquals(Parser0.failWith(mes).?.parse(str), Right((str, None)))
     }
   }
 
@@ -1604,8 +1604,8 @@ class ParserTest extends munit.ScalaCheckSuite {
 
   property("!anyChar == end") {
     forAll { (str: String) =>
-      val left = !Parser.anyChar
-      val right = Parser.end
+      val left = !Parser0.anyChar
+      val right = Parser0.end
 
       val leftRes = left.parse(str).toOption
       val rightRes = right.parse(str).toOption
@@ -1615,8 +1615,8 @@ class ParserTest extends munit.ScalaCheckSuite {
 
   property("!fail == unit") {
     forAll { (str: String) =>
-      val left = !Parser.fail
-      val right = Parser.unit
+      val left = !Parser0.fail
+      val right = Parser0.unit
 
       val leftRes = left.parse(str)
       val rightRes = right.parse(str)
@@ -1626,8 +1626,8 @@ class ParserTest extends munit.ScalaCheckSuite {
 
   property("!pure(_) == fail") {
     forAll { (str: String, i: Int) =>
-      val left = !Parser.pure(i)
-      val right = Parser.fail
+      val left = !Parser0.pure(i)
+      val right = Parser0.fail
 
       val leftRes = left.parse(str).toOption
       val rightRes = right.parse(str).toOption
@@ -1637,14 +1637,14 @@ class ParserTest extends munit.ScalaCheckSuite {
 
   property("anyChar.repAs[String] parses the whole string") {
     forAll { (str: String) =>
-      assertEquals(Parser.anyChar.repAs[String].parse(str), Right(("", str)))
+      assertEquals(Parser0.anyChar.repAs[String].parse(str), Right(("", str)))
     }
   }
 
   property("string.soft ~ string is the same as concatenating the string") {
     forAll { (str1: String, str2: String, content: String) =>
-      val left = (Parser.string(str1).soft ~ Parser.string(str2)).void
-      val right = Parser.string(str1 + str2)
+      val left = (Parser0.string(str1).soft ~ Parser0.string(str2)).void
+      val right = Parser0.string(str1 + str2)
 
       val leftRes = left.parse(content).toOption
       val rightRes = right.parse(content).toOption
@@ -1653,50 +1653,50 @@ class ParserTest extends munit.ScalaCheckSuite {
     }
   }
 
-  property("Parser.string(f).string == Parser.string(f).as(f)") {
+  property("Parser0.string(f).string == Parser0.string(f).as(f)") {
     forAll { (f: String) =>
       if (f.length > 1)
-        assertEquals(Parser.string(f).string, Parser.string(f).as(f))
+        assertEquals(Parser0.string(f).string, Parser0.string(f).as(f))
 
     }
   }
 
   property("char(c).as(c) == charIn(c)") {
     forAll { (c: Char) =>
-      assertEquals(Parser.char(c).as(c.toString), Parser.char(c).string)
-      assertEquals(Parser.char(c).as(c), Parser.charIn(c))
-      assertEquals(Parser.char(c).void.as(c), Parser.charIn(c))
-      assertEquals(Parser.char(c).string.as(c), Parser.charIn(c))
+      assertEquals(Parser0.char(c).as(c.toString), Parser0.char(c).string)
+      assertEquals(Parser0.char(c).as(c), Parser0.charIn(c))
+      assertEquals(Parser0.char(c).void.as(c), Parser0.charIn(c))
+      assertEquals(Parser0.char(c).string.as(c), Parser0.charIn(c))
     }
   }
 
   property("select(pa.map(Left(_)))(pf) == (pa, pf).mapN((a, fn) => fn(a))") {
-    forAll { (pa: Parser[Int], pf: Parser[Int => String], str: String) =>
+    forAll { (pa: Parser0[Int], pf: Parser0[Int => String], str: String) =>
       assertEquals(
-        Parser.select(pa.map(Left(_)))(pf).parse(str),
+        Parser0.select(pa.map(Left(_)))(pf).parse(str),
         (pa, pf).mapN((a, f) => f(a)).parse(str)
       )
     }
   }
 
   property("select1(pa.map(Left(_)))(pf) == (pa, pf).mapN((a, fn) => fn(a))") {
-    forAll { (pa: Parser1[Int], pf: Parser[Int => String], str: String) =>
+    forAll { (pa: Parser1[Int], pf: Parser0[Int => String], str: String) =>
       assertEquals(
-        Parser.select(pa.map(Left(_)))(pf).parse(str),
+        Parser0.select(pa.map(Left(_)))(pf).parse(str),
         (pa, pf).mapN((a, f) => f(a)).parse(str)
       )
     }
   }
 
   property("select(pa.map(Right(_)))(pf) == pa") {
-    forAll { (pa: Parser[String], pf: Parser[Int => String], str: String) =>
-      assertEquals(Parser.select(pa.map(Right(_)))(pf).parse(str), pa.parse(str))
+    forAll { (pa: Parser0[String], pf: Parser0[Int => String], str: String) =>
+      assertEquals(Parser0.select(pa.map(Right(_)))(pf).parse(str), pa.parse(str))
     }
   }
 
   property("select1(pa.map(Right(_)))(pf) == pa") {
-    forAll { (pa: Parser1[String], pf: Parser[Int => String], str: String) =>
-      assertEquals(Parser.select1(pa.map(Right(_)))(pf).parse(str), pa.parse(str))
+    forAll { (pa: Parser1[String], pf: Parser0[Int => String], str: String) =>
+      assertEquals(Parser0.select1(pa.map(Right(_)))(pf).parse(str), pa.parse(str))
     }
   }
 
@@ -1718,17 +1718,17 @@ class ParserTest extends munit.ScalaCheckSuite {
   property("select on pure values works as expected") {
     forAll { (left: Option[Either[Int, String]], right: Option[Int => String], str: String) =>
       val pleft = left match {
-        case Some(e) => Parser.pure(e)
-        case None => Parser.fail
+        case Some(e) => Parser0.pure(e)
+        case None => Parser0.fail
       }
 
       val pright = right match {
-        case Some(f) => Parser.pure(f)
-        case None => Parser.fail
+        case Some(f) => Parser0.pure(f)
+        case None => Parser0.fail
       }
 
       assertEquals(
-        Parser.select(pleft)(pright).parse(str).toOption.map(_._2),
+        Parser0.select(pleft)(pright).parse(str).toOption.map(_._2),
         left.flatMap {
           case Left(i) => right.map(_(i))
           case Right(s) =>
@@ -1740,7 +1740,7 @@ class ParserTest extends munit.ScalaCheckSuite {
   }
 
   property("mapFilter is the same as filter + map") {
-    forAll { (pa: Parser[Int], fn: Int => Option[String], str: String) =>
+    forAll { (pa: Parser0[Int], fn: Int => Option[String], str: String) =>
       val left = pa.mapFilter(fn)
       val right = pa.map(fn).filter(_.isDefined).map(_.get)
 
@@ -1758,7 +1758,7 @@ class ParserTest extends munit.ScalaCheckSuite {
   }
 
   property("collect is the same as filter + map") {
-    forAll { (pa: Parser[Int], fn: Int => Option[String], str: String) =>
+    forAll { (pa: Parser0[Int], fn: Int => Option[String], str: String) =>
       val left = pa.collect {
         case i if fn(i).isDefined => fn(i).get
       }

--- a/core/shared/src/test/scala/cats/parse/ParserTest.scala
+++ b/core/shared/src/test/scala/cats/parse/ParserTest.scala
@@ -79,9 +79,9 @@ object ParserGen {
       GenT(Parser0.string0(str))
     }
 
-  val ignoreCase: Gen[GenT[Parser0]] =
+  val ignoreCase0: Gen[GenT[Parser0]] =
     Arbitrary.arbitrary[String].map { str =>
-      GenT(Parser0.ignoreCase(str))
+      GenT(Parser0.ignoreCase0(str))
     }
 
   val charIn: Gen[GenT[Parser0]] =
@@ -109,7 +109,7 @@ object ParserGen {
   val ignoreCase1: Gen[GenT[Parser]] =
     Arbitrary.arbitrary[String].map { str =>
       if (str.isEmpty) GenT(Parser0.fail: Parser[Unit])
-      else GenT(Parser0.ignoreCase1(str))
+      else GenT(Parser0.ignoreCase(str))
     }
 
   val fail: Gen[GenT[Parser0]] =
@@ -443,7 +443,7 @@ object ParserGen {
           }))
       ),
       (5, expect0),
-      (1, ignoreCase),
+      (1, ignoreCase0),
       (5, charIn),
       (1, Gen.oneOf(GenT(Parser0.start), GenT(Parser0.end), GenT(Parser0.index))),
       (1, fail),
@@ -548,8 +548,8 @@ class ParserTest extends munit.ScalaCheckSuite {
 
   val fooP = Parser0.string("foo")
   val barP = Parser0.string("bar")
-  val fooCIP = Parser0.ignoreCase1("foo")
-  val cCIP = Parser0.ignoreCase1("a")
+  val fooCIP = Parser0.ignoreCase("foo")
+  val cCIP = Parser0.ignoreCase("a")
   val cCIP1 = Parser0.ignoreCaseChar('a')
   val abcCI = Parser0.ignoreCaseCharIn('a', 'b', 'c')
 

--- a/core/shared/src/test/scala/cats/parse/ParserTest.scala
+++ b/core/shared/src/test/scala/cats/parse/ParserTest.scala
@@ -1074,17 +1074,17 @@ class ParserTest extends munit.ScalaCheckSuite {
     }
   }
 
-  property("charsWhile/charWhile consistency") {
+  property("charsWhile/charsWhere consistency") {
     forAll(
       Gen.choose(0, 100).flatMap(Gen.listOfN(_, Gen.choose(Char.MinValue, Char.MaxValue))),
       Arbitrary.arbitrary[String]
     ) { (chars, str) =>
       val pred = chars.toSet
-      val p1a = Parser0.charsWhile(pred)
+      val p1a = Parser0.charsWhile0(pred)
       val p1b = Parser0.charWhere(pred).rep0.string
       assertEquals(p1a.parse(str), p1b.parse(str))
 
-      val p2a = Parser0.charsWhile1(pred)
+      val p2a = Parser0.charsWhile(pred)
       val p2b = Parser0.charWhere(pred).rep.string
       assertEquals(p2a.parse(str), p2b.parse(str))
     }

--- a/core/shared/src/test/scala/cats/parse/ParserTest.scala
+++ b/core/shared/src/test/scala/cats/parse/ParserTest.scala
@@ -266,7 +266,7 @@ object ParserGen {
         }
 
       Gen.zip(genPR, gfn).map { case (pab, fn) =>
-        GenT(Parser0.select(pab)(fn))(genRes2.cogen)
+        GenT(Parser0.select0(pab)(fn))(genRes2.cogen)
       }
     }
 
@@ -361,7 +361,7 @@ object ParserGen {
         }
 
       Gen.zip(genPR1, gfn).map { case (pab, fn) =>
-        GenT(Parser0.select1(pab)(fn))(genRes2.cogen)
+        GenT(Parser0.select(pab)(fn))(genRes2.cogen)
       }
     }
 
@@ -1673,7 +1673,7 @@ class ParserTest extends munit.ScalaCheckSuite {
   property("select(pa.map(Left(_)))(pf) == (pa, pf).mapN((a, fn) => fn(a))") {
     forAll { (pa: Parser0[Int], pf: Parser0[Int => String], str: String) =>
       assertEquals(
-        Parser0.select(pa.map(Left(_)))(pf).parse(str),
+        Parser0.select0(pa.map(Left(_)))(pf).parse(str),
         (pa, pf).mapN((a, f) => f(a)).parse(str)
       )
     }
@@ -1690,13 +1690,13 @@ class ParserTest extends munit.ScalaCheckSuite {
 
   property("select(pa.map(Right(_)))(pf) == pa") {
     forAll { (pa: Parser0[String], pf: Parser0[Int => String], str: String) =>
-      assertEquals(Parser0.select(pa.map(Right(_)))(pf).parse(str), pa.parse(str))
+      assertEquals(Parser0.select0(pa.map(Right(_)))(pf).parse(str), pa.parse(str))
     }
   }
 
   property("select1(pa.map(Right(_)))(pf) == pa") {
     forAll { (pa: Parser[String], pf: Parser0[Int => String], str: String) =>
-      assertEquals(Parser0.select1(pa.map(Right(_)))(pf).parse(str), pa.parse(str))
+      assertEquals(Parser0.select(pa.map(Right(_)))(pf).parse(str), pa.parse(str))
     }
   }
 
@@ -1728,7 +1728,7 @@ class ParserTest extends munit.ScalaCheckSuite {
       }
 
       assertEquals(
-        Parser0.select(pleft)(pright).parse(str).toOption.map(_._2),
+        Parser0.select0(pleft)(pright).parse(str).toOption.map(_._2),
         left.flatMap {
           case Left(i) => right.map(_(i))
           case Right(s) =>

--- a/core/shared/src/test/scala/cats/parse/ParserTest.scala
+++ b/core/shared/src/test/scala/cats/parse/ParserTest.scala
@@ -84,7 +84,7 @@ object ParserGen {
       GenT(Parser0.ignoreCase0(str))
     }
 
-  val charIn: Gen[GenT[Parser0]] =
+  val charIn0: Gen[GenT[Parser0]] =
     Gen.oneOf(
       Arbitrary.arbitrary[List[Char]].map { cs =>
         GenT(Parser0.charIn(cs): Parser0[Char])
@@ -92,7 +92,7 @@ object ParserGen {
       Gen.const(GenT(Parser0.anyChar: Parser0[Char]))
     )
 
-  val charIn1: Gen[GenT[Parser]] =
+  val charIn: Gen[GenT[Parser]] =
     Gen.oneOf(
       Arbitrary.arbitrary[List[Char]].map { cs =>
         GenT(Parser0.charIn(cs))
@@ -444,7 +444,7 @@ object ParserGen {
       ),
       (5, expect0),
       (1, ignoreCase0),
-      (5, charIn),
+      (5, charIn0),
       (1, Gen.oneOf(GenT(Parser0.start), GenT(Parser0.end), GenT(Parser0.index))),
       (1, fail),
       (1, failWith),
@@ -472,7 +472,7 @@ object ParserGen {
     Gen.frequency(
       (8, expect1),
       (2, ignoreCase),
-      (8, charIn1),
+      (8, charIn),
       (1, Gen.choose(Char.MinValue, Char.MaxValue).map { c => GenT(Parser0.char(c)) }),
       (2, rec.map(void(_))),
       (2, rec.map(string(_))),

--- a/core/shared/src/test/scala/cats/parse/ParserTest.scala
+++ b/core/shared/src/test/scala/cats/parse/ParserTest.scala
@@ -106,7 +106,7 @@ object ParserGen {
       else GenT(Parser0.string(str))
     }
 
-  val ignoreCase1: Gen[GenT[Parser]] =
+  val ignoreCase: Gen[GenT[Parser]] =
     Arbitrary.arbitrary[String].map { str =>
       if (str.isEmpty) GenT(Parser0.fail: Parser[Unit])
       else GenT(Parser0.ignoreCase(str))
@@ -471,7 +471,7 @@ object ParserGen {
 
     Gen.frequency(
       (8, expect1),
-      (2, ignoreCase1),
+      (2, ignoreCase),
       (8, charIn1),
       (1, Gen.choose(Char.MinValue, Char.MaxValue).map { c => GenT(Parser0.char(c)) }),
       (2, rec.map(void(_))),

--- a/core/shared/src/test/scala/cats/parse/ParserTest.scala
+++ b/core/shared/src/test/scala/cats/parse/ParserTest.scala
@@ -192,10 +192,10 @@ object ParserGen {
     implicit val ca: Cogen[ga.A] = ga.cogen
     implicit val cb: Cogen[gb.A] = gb.cogen
     Gen.oneOf(
-      GenT[Parser, (ga.A, gb.A)](Parser.product(ga.fa, gb.fa)),
+      GenT[Parser, (ga.A, gb.A)](Parser.product10(ga.fa, gb.fa)),
       GenT[Parser, ga.A](ga.fa <* gb.fa),
       GenT[Parser, gb.A](ga.fa *> gb.fa),
-      GenT[Parser, (ga.A, ga.A)](Parser.product(ga.fa, ga.fa))
+      GenT[Parser, (ga.A, ga.A)](Parser.product10(ga.fa, ga.fa))
     )
   }
 
@@ -579,7 +579,7 @@ class ParserTest extends munit.ScalaCheckSuite {
 
   test("product tests") {
     parseTest(Parser.product01(fooP, barP), "foobar", ((), ()))
-    parseTest(Parser.product(fooP, barP), "foobar", ((), ()))
+    parseTest(Parser.product10(fooP, barP), "foobar", ((), ()))
     parseTest(Parser.product0(fooP, barP), "foobar", ((), ()))
   }
 
@@ -1177,11 +1177,11 @@ class ParserTest extends munit.ScalaCheckSuite {
     forAll(ParserGen.gen, ParserGen.gen0, Arbitrary.arbitrary[String]) { (p1, p2, str) =>
       assertEquals(
         (p1.fa *> p2.fa).parse(str),
-        Parser.product(p1.fa.void, p2.fa).map(_._2).parse(str)
+        Parser.product10(p1.fa.void, p2.fa).map(_._2).parse(str)
       )
       assertEquals(
         (p1.fa <* p2.fa).parse(str),
-        Parser.product(p1.fa, p2.fa.void).map(_._1).parse(str)
+        Parser.product10(p1.fa, p2.fa.void).map(_._1).parse(str)
       )
     }
   }

--- a/core/shared/src/test/scala/cats/parse/ParserTest.scala
+++ b/core/shared/src/test/scala/cats/parse/ParserTest.scala
@@ -92,7 +92,7 @@ object ParserGen {
       Gen.const(GenT(Parser0.anyChar: Parser0[Char]))
     )
 
-  val charIn1: Gen[GenT[Parser1]] =
+  val charIn1: Gen[GenT[Parser]] =
     Gen.oneOf(
       Arbitrary.arbitrary[List[Char]].map { cs =>
         GenT(Parser0.charIn(cs))
@@ -100,15 +100,15 @@ object ParserGen {
       Gen.const(GenT(Parser0.anyChar))
     )
 
-  val expect1: Gen[GenT[Parser1]] =
+  val expect1: Gen[GenT[Parser]] =
     Arbitrary.arbitrary[String].map { str =>
-      if (str.isEmpty) GenT(Parser0.fail: Parser1[Unit])
+      if (str.isEmpty) GenT(Parser0.fail: Parser[Unit])
       else GenT(Parser0.string1(str))
     }
 
-  val ignoreCase1: Gen[GenT[Parser1]] =
+  val ignoreCase1: Gen[GenT[Parser]] =
     Arbitrary.arbitrary[String].map { str =>
-      if (str.isEmpty) GenT(Parser0.fail: Parser1[Unit])
+      if (str.isEmpty) GenT(Parser0.fail: Parser[Unit])
       else GenT(Parser0.ignoreCase1(str))
     }
 
@@ -123,35 +123,35 @@ object ParserGen {
   def void(g: GenT[Parser0]): GenT[Parser0] =
     GenT(Parser0.void(g.fa))
 
-  def void1(g: GenT[Parser1]): GenT[Parser1] =
+  def void1(g: GenT[Parser]): GenT[Parser] =
     GenT(Parser0.void1(g.fa))
 
   def string(g: GenT[Parser0]): GenT[Parser0] =
     GenT(Parser0.string(g.fa))
 
-  def string1(g: GenT[Parser1]): GenT[Parser1] =
+  def string1(g: GenT[Parser]): GenT[Parser] =
     GenT(Parser0.string1(g.fa))
 
   def backtrack(g: GenT[Parser0]): GenT[Parser0] =
     GenT(g.fa.backtrack)(g.cogen)
 
-  def backtrack1(g: GenT[Parser1]): GenT[Parser1] =
+  def backtrack1(g: GenT[Parser]): GenT[Parser] =
     GenT(g.fa.backtrack)(g.cogen)
 
   def defer(g: GenT[Parser0]): GenT[Parser0] =
     GenT(Defer[Parser0].defer(g.fa))(g.cogen)
 
-  def defer1(g: GenT[Parser1]): GenT[Parser1] =
-    GenT(Defer[Parser1].defer(g.fa))(g.cogen)
+  def defer1(g: GenT[Parser]): GenT[Parser] =
+    GenT(Defer[Parser].defer(g.fa))(g.cogen)
 
-  def rep(g: GenT[Parser1]): GenT[Parser0] = {
+  def rep(g: GenT[Parser]): GenT[Parser0] = {
     implicit val cg = g.cogen
     GenT[Parser0, List[g.A]](g.fa.rep)
   }
 
-  def rep1(g: GenT[Parser1]): GenT[Parser1] = {
+  def rep1(g: GenT[Parser]): GenT[Parser] = {
     implicit val cg = g.cogen
-    GenT[Parser1, List[g.A]](g.fa.rep1.map(_.toList))
+    GenT[Parser, List[g.A]](g.fa.rep1.map(_.toList))
   }
 
   def product(ga: GenT[Parser0], gb: GenT[Parser0]): Gen[GenT[Parser0]] = {
@@ -173,40 +173,40 @@ object ParserGen {
     )
   }
 
-  def product1(ga: GenT[Parser1], gb: GenT[Parser1]): Gen[GenT[Parser1]] = {
+  def product1(ga: GenT[Parser], gb: GenT[Parser]): Gen[GenT[Parser]] = {
     implicit val ca: Cogen[ga.A] = ga.cogen
     implicit val cb: Cogen[gb.A] = gb.cogen
     Gen.oneOf(
-      GenT[Parser1, (ga.A, gb.A)](FlatMap[Parser1].product(ga.fa, gb.fa)),
-      GenT[Parser1, (ga.A, gb.A)](FlatMap[Parser1].map2(ga.fa, gb.fa)((_, _))),
-      GenT[Parser1, (ga.A, gb.A)](
-        FlatMap[Parser1].map2Eval(ga.fa, Eval.later(gb.fa))((_, _)).value
+      GenT[Parser, (ga.A, gb.A)](FlatMap[Parser].product(ga.fa, gb.fa)),
+      GenT[Parser, (ga.A, gb.A)](FlatMap[Parser].map2(ga.fa, gb.fa)((_, _))),
+      GenT[Parser, (ga.A, gb.A)](
+        FlatMap[Parser].map2Eval(ga.fa, Eval.later(gb.fa))((_, _)).value
       ),
-      GenT[Parser1, (ga.A, gb.A)](FlatMap[Parser1].map2Eval(ga.fa, Eval.now(gb.fa))((_, _)).value)
+      GenT[Parser, (ga.A, gb.A)](FlatMap[Parser].map2Eval(ga.fa, Eval.now(gb.fa))((_, _)).value)
     )
   }
 
-  def product10(ga: GenT[Parser1], gb: GenT[Parser0]): Gen[GenT[Parser1]] = {
+  def product10(ga: GenT[Parser], gb: GenT[Parser0]): Gen[GenT[Parser]] = {
     implicit val ca: Cogen[ga.A] = ga.cogen
     implicit val cb: Cogen[gb.A] = gb.cogen
     Gen.oneOf(
-      GenT[Parser1, (ga.A, gb.A)](Parser0.product10(ga.fa, gb.fa)),
-      GenT[Parser1, ga.A](ga.fa <* gb.fa),
-      GenT[Parser1, gb.A](ga.fa *> gb.fa),
-      GenT[Parser1, (ga.A, ga.A)](Parser0.product10(ga.fa, ga.fa))
+      GenT[Parser, (ga.A, gb.A)](Parser0.product10(ga.fa, gb.fa)),
+      GenT[Parser, ga.A](ga.fa <* gb.fa),
+      GenT[Parser, gb.A](ga.fa *> gb.fa),
+      GenT[Parser, (ga.A, ga.A)](Parser0.product10(ga.fa, ga.fa))
     )
   }
 
-  def softProduct1(ga: GenT[Parser1], gb: GenT[Parser0]): Gen[GenT[Parser1]] = {
+  def softProduct1(ga: GenT[Parser], gb: GenT[Parser0]): Gen[GenT[Parser]] = {
     implicit val ca: Cogen[ga.A] = ga.cogen
     implicit val cb: Cogen[gb.A] = gb.cogen
     Gen.oneOf(
-      // left is Parser1
-      GenT[Parser1, (ga.A, gb.A)](ga.fa.soft ~ gb.fa),
-      // right is Parser1
-      GenT[Parser1, (gb.A, ga.A)](gb.fa.with1.soft ~ ga.fa),
+      // left is Parser
+      GenT[Parser, (ga.A, gb.A)](ga.fa.soft ~ gb.fa),
+      // right is Parser
+      GenT[Parser, (gb.A, ga.A)](gb.fa.with1.soft ~ ga.fa),
       // both are parser1
-      GenT[Parser1, (ga.A, ga.A)](ga.fa.soft ~ ga.fa)
+      GenT[Parser, (ga.A, ga.A)](ga.fa.soft ~ ga.fa)
     )
   }
 
@@ -224,7 +224,7 @@ object ParserGen {
     }
   }
 
-  def mapped1(ga: GenT[Parser1]): Gen[GenT[Parser1]] = {
+  def mapped1(ga: GenT[Parser]): Gen[GenT[Parser]] = {
     pures.flatMap { genRes =>
       implicit val ca: Cogen[ga.A] = ga.cogen
       implicit val cb: Cogen[genRes.A] = genRes.cogen
@@ -232,7 +232,7 @@ object ParserGen {
       fnGen.flatMap { fn =>
         Gen.oneOf(
           GenT(ga.fa.map(fn)),
-          GenT(FlatMap[Parser1].map(ga.fa)(fn))
+          GenT(FlatMap[Parser].map(ga.fa)(fn))
         )
       }
     }
@@ -295,7 +295,7 @@ object ParserGen {
     }
 
   // if we use a Parser0 here, we could loop forever parsing nothing
-  def tailRecM(ga: Gen[GenT[Parser1]]): Gen[GenT[Parser0]] =
+  def tailRecM(ga: Gen[GenT[Parser]]): Gen[GenT[Parser0]] =
     Gen.zip(pures, pures).flatMap { case (genRes1, genRes2) =>
       val genPR: Gen[Parser0[Either[genRes1.A, genRes2.A]]] = {
         ga.flatMap { init =>
@@ -317,9 +317,9 @@ object ParserGen {
         }
     }
 
-  def tailRecM1(ga: Gen[GenT[Parser1]]): Gen[GenT[Parser1]] =
+  def tailRecM1(ga: Gen[GenT[Parser]]): Gen[GenT[Parser]] =
     Gen.zip(pures, pures).flatMap { case (genRes1, genRes2) =>
-      val genPR: Gen[Parser1[Either[genRes1.A, genRes2.A]]] = {
+      val genPR: Gen[Parser[Either[genRes1.A, genRes2.A]]] = {
         ga.flatMap { init =>
           val mapFn: Gen[init.A => Either[genRes1.A, genRes2.A]] =
             Gen.function1(Gen.either(genRes1.fa, genRes2.fa))(init.cogen)
@@ -335,13 +335,13 @@ object ParserGen {
       Gen
         .zip(genRes1.fa, gfn)
         .map { case (init, fn) =>
-          GenT(FlatMap[Parser1].tailRecM(init)(fn))(genRes2.cogen)
+          GenT(FlatMap[Parser].tailRecM(init)(fn))(genRes2.cogen)
         }
     }
 
-  def selected1(ga1: Gen[GenT[Parser1]], ga0: Gen[GenT[Parser0]]): Gen[GenT[Parser1]] =
+  def selected1(ga1: Gen[GenT[Parser]], ga0: Gen[GenT[Parser0]]): Gen[GenT[Parser]] =
     Gen.zip(pures, pures).flatMap { case (genRes1, genRes2) =>
-      val genPR1: Gen[Parser1[Either[genRes1.A, genRes2.A]]] = {
+      val genPR1: Gen[Parser[Either[genRes1.A, genRes2.A]]] = {
         ga1.flatMap { init =>
           val mapFn: Gen[init.A => Either[genRes1.A, genRes2.A]] =
             Gen.function1(Gen.either(genRes1.fa, genRes2.fa))(init.cogen)
@@ -365,9 +365,9 @@ object ParserGen {
       }
     }
 
-  def flatMapped1(ga: Gen[GenT[Parser0]], ga1: Gen[GenT[Parser1]]): Gen[GenT[Parser1]] =
+  def flatMapped1(ga: Gen[GenT[Parser0]], ga1: Gen[GenT[Parser]]): Gen[GenT[Parser]] =
     Gen.zip(ga, ga1, pures).flatMap { case (parser, parser1, genRes) =>
-      val genPR: Gen[Parser1[genRes.A]] = {
+      val genPR: Gen[Parser[genRes.A]] = {
         ga1.flatMap { init =>
           val mapFn: Gen[init.A => genRes.A] =
             Gen.function1(genRes.fa)(init.cogen)
@@ -378,10 +378,10 @@ object ParserGen {
         }
       }
 
-      val gfn: Gen[parser.A => Parser1[genRes.A]] =
+      val gfn: Gen[parser.A => Parser[genRes.A]] =
         Gen.function1(genPR)(parser.cogen)
 
-      val gfn1: Gen[parser1.A => Parser1[genRes.A]] =
+      val gfn1: Gen[parser1.A => Parser[genRes.A]] =
         Gen.function1(genPR)(parser1.cogen)
 
       Gen.frequency(
@@ -390,7 +390,7 @@ object ParserGen {
           gfn1.flatMap { fn =>
             Gen.oneOf(
               GenT(parser1.fa.flatMap(fn))(genRes.cogen), // 1 -> 0
-              GenT(FlatMap[Parser1].flatMap(parser1.fa)(fn))(genRes.cogen) // 1 -> 1
+              GenT(FlatMap[Parser].flatMap(parser1.fa)(fn))(genRes.cogen) // 1 -> 1
             )
           }
         ),
@@ -416,7 +416,7 @@ object ParserGen {
     }
   }
 
-  def orElse1(ga: GenT[Parser1], gb: GenT[Parser1], res: GenT[Gen]): Gen[GenT[Parser1]] = {
+  def orElse1(ga: GenT[Parser], gb: GenT[Parser], res: GenT[Gen]): Gen[GenT[Parser]] = {
     val genFn1: Gen[ga.A => res.A] = Gen.function1(res.fa)(ga.cogen)
     val genFn2: Gen[gb.A => res.A] = Gen.function1(res.fa)(gb.cogen)
     implicit val cogenResA: Cogen[res.A] = res.cogen
@@ -424,7 +424,7 @@ object ParserGen {
     Gen.zip(genFn1, genFn2).flatMap { case (f1, f2) =>
       Gen.oneOf(
         GenT(ga.fa.map(f1).orElse1(gb.fa.map(f2))),
-        GenT(MonoidK[Parser1].combineK(ga.fa.map(f1), gb.fa.map(f2)))
+        GenT(MonoidK[Parser].combineK(ga.fa.map(f1), gb.fa.map(f2)))
       )
     }
   }
@@ -466,7 +466,7 @@ object ParserGen {
   }
 
   // Generate a random parser
-  lazy val gen1: Gen[GenT[Parser1]] = {
+  lazy val gen1: Gen[GenT[Parser]] = {
     val rec = Gen.lzy(gen1)
 
     Gen.frequency(
@@ -502,7 +502,7 @@ object ParserGen {
       fn <- Gen.function1(genA)(genT.cogen)
     } yield genT.fa.map(fn)
 
-  def genParser1[A](genA: Gen[A]): Gen[Parser1[A]] =
+  def genParser[A](genA: Gen[A]): Gen[Parser[A]] =
     for {
       genT <- gen1
       fn <- Gen.function1(genA)(genT.cogen)
@@ -511,13 +511,13 @@ object ParserGen {
   implicit def arbParser0[A: Arbitrary]: Arbitrary[Parser0[A]] =
     Arbitrary(genParser0(Arbitrary.arbitrary[A]))
 
-  implicit def arbParser1[A: Arbitrary]: Arbitrary[Parser1[A]] =
-    Arbitrary(genParser1(Arbitrary.arbitrary[A]))
+  implicit def arbParser[A: Arbitrary]: Arbitrary[Parser[A]] =
+    Arbitrary(genParser(Arbitrary.arbitrary[A]))
 }
 
 class ParserTest extends munit.ScalaCheckSuite {
 
-  import ParserGen.{arbParser0, arbParser1}
+  import ParserGen.{arbParser0, arbParser}
 
   val tests: Int = if (BitSetUtil.isScalaJs) 50 else 2000
 
@@ -660,11 +660,11 @@ class ParserTest extends munit.ScalaCheckSuite {
     }
   }
 
-  property("voided only changes the result Parser1") {
+  property("voided only changes the result Parser") {
     forAll(ParserGen.gen1, Arbitrary.arbitrary[String]) { (genP, str) =>
       val r1 = genP.fa.parse(str)
       val r2 = genP.fa.void.parse(str)
-      val r3 = FlatMap[Parser1].void(genP.fa).parse(str)
+      val r3 = FlatMap[Parser].void(genP.fa).parse(str)
       val r4 = genP.fa.as(()).parse(str)
       val r5 = ((genP.fa.void: Parser0[Unit]) <* Monad[Parser0].unit).parse(str)
 
@@ -887,7 +887,7 @@ class ParserTest extends munit.ScalaCheckSuite {
     }
   }
 
-  property("a1.soft ~ b composes as expected Parser1") {
+  property("a1.soft ~ b composes as expected Parser") {
     forAll(ParserGen.gen1, ParserGen.gen, Arbitrary.arbitrary[String]) { (p1, p2, str) =>
       val composed = p1.fa.soft ~ p2.fa
       val cres = composed.parse(str)
@@ -967,7 +967,7 @@ class ParserTest extends munit.ScalaCheckSuite {
 
   test("defer1 does not run eagerly") {
     var cnt = 0
-    val res = Defer[Parser1].defer {
+    val res = Defer[Parser].defer {
       cnt += 1
       Parser0.string1("foo")
     }
@@ -1015,7 +1015,7 @@ class ParserTest extends munit.ScalaCheckSuite {
 
   property("rep can be reimplemented with oneOf and defer") {
     forAll(ParserGen.gen1, Arbitrary.arbitrary[String]) { (genP, str) =>
-      def rep[A](pa: Parser1[A]): Parser0[List[A]] =
+      def rep[A](pa: Parser[A]): Parser0[List[A]] =
         Defer[Parser0].fix[List[A]] { tail =>
           (pa ~ tail)
             .map { case (h, t) => h :: t }
@@ -1093,7 +1093,7 @@ class ParserTest extends munit.ScalaCheckSuite {
   property("MonoidK[Parser0].empty never succeeds") {
     forAll { (str: String) =>
       assert(MonoidK[Parser0].empty.parse(str).isLeft)
-      assert(MonoidK[Parser1].empty.parse(str).isLeft)
+      assert(MonoidK[Parser].empty.parse(str).isLeft)
     }
   }
 
@@ -1119,7 +1119,7 @@ class ParserTest extends munit.ScalaCheckSuite {
     }
   }
 
-  property("Parser1 fails or consumes 1 or more") {
+  property("Parser fails or consumes 1 or more") {
     forAll(ParserGen.gen1, Arbitrary.arbitrary[String]) { (genP, str) =>
       val res0 = genP.fa.parse(str)
       res0 match {
@@ -1201,7 +1201,7 @@ class ParserTest extends munit.ScalaCheckSuite {
     }
   }
 
-  property("parse between open and close with Parser1 this") {
+  property("parse between open and close with Parser this") {
     forAll(ParserGen.gen1, ParserGen.gen, ParserGen.gen, Arbitrary.arbitrary[String]) {
       (genP1, genP, genQ, str) =>
         val pa = genP1.fa.between(genP.fa, genQ.fa)
@@ -1211,7 +1211,7 @@ class ParserTest extends munit.ScalaCheckSuite {
     }
   }
 
-  property("surroundedBy consistent with between with Parser1 this") {
+  property("surroundedBy consistent with between with Parser this") {
     forAll(ParserGen.gen1, ParserGen.gen, Arbitrary.arbitrary[String]) { (genP1, genP, str) =>
       val pa = genP1.fa.between(genP.fa, genP.fa)
       val pb = genP1.fa.surroundedBy(genP.fa)
@@ -1220,7 +1220,7 @@ class ParserTest extends munit.ScalaCheckSuite {
     }
   }
 
-  property("parse between open and close with Parser1 args") {
+  property("parse between open and close with Parser args") {
     forAll(ParserGen.gen, ParserGen.gen1, ParserGen.gen1, Arbitrary.arbitrary[String]) {
       (genP1, genP, genQ, str) =>
         val pa = genP1.fa.with1.between(genP.fa, genQ.fa)
@@ -1230,7 +1230,7 @@ class ParserTest extends munit.ScalaCheckSuite {
     }
   }
 
-  property("surroundedBy consistent with between with Parser1 this") {
+  property("surroundedBy consistent with between with Parser this") {
     forAll(ParserGen.gen1, ParserGen.gen, Arbitrary.arbitrary[String]) { (genP1, genP, str) =>
       val pa = genP1.fa.between(genP.fa, genP.fa)
       val pb = genP1.fa.surroundedBy(genP.fa)
@@ -1473,7 +1473,7 @@ class ParserTest extends munit.ScalaCheckSuite {
 
   property("a.repAs[Vector[A]] matches a.rep.map(_.toVector)") {
     forAll(ParserGen.gen1, Arbitrary.arbitrary[String]) { (a, str) =>
-      val pa: Parser1[a.A] = a.fa
+      val pa: Parser[a.A] = a.fa
 
       val left = pa.repAs[Vector[a.A]]
       val right = pa.rep.map(_.toVector)
@@ -1486,7 +1486,7 @@ class ParserTest extends munit.ScalaCheckSuite {
 
   property("a.repAs1[Vector[A]] matches a.rep1.map(_.toList.toVector)") {
     forAll(ParserGen.gen1, Arbitrary.arbitrary[String]) { (a, str) =>
-      val pa: Parser1[a.A] = a.fa
+      val pa: Parser[a.A] = a.fa
 
       val left = pa.repAs1[Vector[a.A]]
       val right = pa.rep1.map(_.toList.toVector)
@@ -1499,7 +1499,7 @@ class ParserTest extends munit.ScalaCheckSuite {
 
   property("a.string.repAs[String] matches a.string.rep.map(_.mkString)") {
     forAll(ParserGen.gen1, Arbitrary.arbitrary[String]) { (a, str) =>
-      val pa: Parser1[String] = a.fa.string
+      val pa: Parser[String] = a.fa.string
 
       val left = pa.repAs[String]
       val right = pa.rep.map(_.mkString)
@@ -1512,7 +1512,7 @@ class ParserTest extends munit.ScalaCheckSuite {
 
   property("a.repAs[Unit] matches a.rep.void") {
     forAll(ParserGen.gen1, Arbitrary.arbitrary[String]) { (a, str) =>
-      val pa: Parser1[a.A] = a.fa
+      val pa: Parser[a.A] = a.fa
 
       val left = pa.repAs[Unit](Accumulator.unitAccumulator)
       val right = pa.rep.void
@@ -1680,7 +1680,7 @@ class ParserTest extends munit.ScalaCheckSuite {
   }
 
   property("select1(pa.map(Left(_)))(pf) == (pa, pf).mapN((a, fn) => fn(a))") {
-    forAll { (pa: Parser1[Int], pf: Parser0[Int => String], str: String) =>
+    forAll { (pa: Parser[Int], pf: Parser0[Int => String], str: String) =>
       assertEquals(
         Parser0.select(pa.map(Left(_)))(pf).parse(str),
         (pa, pf).mapN((a, f) => f(a)).parse(str)
@@ -1695,7 +1695,7 @@ class ParserTest extends munit.ScalaCheckSuite {
   }
 
   property("select1(pa.map(Right(_)))(pf) == pa") {
-    forAll { (pa: Parser1[String], pf: Parser0[Int => String], str: String) =>
+    forAll { (pa: Parser[String], pf: Parser0[Int => String], str: String) =>
       assertEquals(Parser0.select1(pa.map(Right(_)))(pf).parse(str), pa.parse(str))
     }
   }
@@ -1748,8 +1748,8 @@ class ParserTest extends munit.ScalaCheckSuite {
     }
   }
 
-  property("mapFilter is the same as filter + map Parser1") {
-    forAll { (pa: Parser1[Int], fn: Int => Option[String], str: String) =>
+  property("mapFilter is the same as filter + map Parser") {
+    forAll { (pa: Parser[Int], fn: Int => Option[String], str: String) =>
       val left = pa.mapFilter(fn)
       val right = pa.map(fn).filter(_.isDefined).map(_.get)
 
@@ -1768,8 +1768,8 @@ class ParserTest extends munit.ScalaCheckSuite {
     }
   }
 
-  property("collect is the same as filter + map Parser1") {
-    forAll { (pa: Parser1[Int], fn: Int => Option[String], str: String) =>
+  property("collect is the same as filter + map Parser") {
+    forAll { (pa: Parser[Int], fn: Int => Option[String], str: String) =>
       val left = pa.collect {
         case i if fn(i).isDefined => fn(i).get
       }

--- a/core/shared/src/test/scala/cats/parse/ParserTest.scala
+++ b/core/shared/src/test/scala/cats/parse/ParserTest.scala
@@ -1321,7 +1321,7 @@ class ParserTest extends munit.ScalaCheckSuite {
 
   property("Parser0.until is like a search") {
     forAll(ParserGen.gen0, Arbitrary.arbitrary[String]) { (a, str) =>
-      val p = Parser0.until(a.fa) *> a.fa
+      val p = Parser0.until0(a.fa) *> a.fa
       def loopMatch(cnt: Int): Option[(String, a.A)] =
         (Parser0.length0(cnt) *> a.fa).parse(str) match {
           case Right(res) => Some(res)

--- a/core/shared/src/test/scala/cats/parse/ParserTest.scala
+++ b/core/shared/src/test/scala/cats/parse/ParserTest.scala
@@ -1046,28 +1046,28 @@ class ParserTest extends munit.ScalaCheckSuite {
     }
   }
 
-  property("repSep with unit sep is the same as rep0") {
+  property("rep0Sep with unit sep is the same as rep0") {
     forAll(ParserGen.gen, Gen.choose(0, Int.MaxValue), Arbitrary.arbitrary[String]) {
       (genP, min0, str) =>
         val min = min0 & Int.MaxValue
-        val p1a = Parser0.repSep(genP.fa, min = min, sep = Parser0.unit)
+        val p1a = Parser0.rep0Sep(genP.fa, min = min, sep = Parser0.unit)
         val p1b = genP.fa.rep0(min = min)
 
         assertEquals(p1a.parse(str), p1b.parse(str))
 
         val min1 = if (min < 1) 1 else min
-        val p2a = Parser0.rep1Sep(genP.fa, min = min1, sep = Parser0.unit)
+        val p2a = Parser0.repSep(genP.fa, min = min1, sep = Parser0.unit)
         val p2b = genP.fa.rep(min = min1)
 
         assertEquals(p2a.parse(str), p2b.parse(str))
     }
   }
 
-  property("rep1Sep with sep = fail is the same as parsing 1") {
+  property("repSep with sep = fail is the same as parsing 1") {
     forAll(ParserGen.gen, Arbitrary.arbitrary[String]) { (genP, str) =>
       assertEquals(
         genP.fa.parse(str),
-        Parser0.rep1Sep(genP.fa, 1, Parser0.fail).parse(str).map { case (rest, nel) =>
+        Parser0.repSep(genP.fa, 1, Parser0.fail).parse(str).map { case (rest, nel) =>
           (rest, nel.head)
         }
       )

--- a/core/shared/src/test/scala/cats/parse/ParserTest.scala
+++ b/core/shared/src/test/scala/cats/parse/ParserTest.scala
@@ -138,10 +138,10 @@ object ParserGen {
   def backtrack1(g: GenT[Parser]): GenT[Parser] =
     GenT(g.fa.backtrack)(g.cogen)
 
-  def defer(g: GenT[Parser0]): GenT[Parser0] =
+  def defer0(g: GenT[Parser0]): GenT[Parser0] =
     GenT(Defer[Parser0].defer(g.fa))(g.cogen)
 
-  def defer1(g: GenT[Parser]): GenT[Parser] =
+  def defer(g: GenT[Parser]): GenT[Parser] =
     GenT(Defer[Parser].defer(g.fa))(g.cogen)
 
   def rep0(g: GenT[Parser]): GenT[Parser0] = {
@@ -451,7 +451,7 @@ object ParserGen {
       (1, rec.map(void(_))),
       (1, rec.map(string(_))),
       (1, rec.map(backtrack(_))),
-      (1, rec.map(defer(_))),
+      (1, rec.map(defer0(_))),
       (1, rec.map { gen => GenT(!gen.fa) }),
       (1, Gen.lzy(gen1.map(rep0(_)))),
       (1, rec.flatMap(mapped(_))),
@@ -477,7 +477,7 @@ object ParserGen {
       (2, rec.map(void1(_))),
       (2, rec.map(string1(_))),
       (2, rec.map(backtrack1(_))),
-      (1, rec.map(defer1(_))),
+      (1, rec.map(defer(_))),
       (1, rec.map(rep(_))),
       (1, selected1(rec, gen)),
       (1, rec.flatMap(mapped1(_))),

--- a/core/shared/src/test/scala/cats/parse/ParserTest.scala
+++ b/core/shared/src/test/scala/cats/parse/ParserTest.scala
@@ -199,7 +199,7 @@ object ParserGen {
     )
   }
 
-  def softProduct(ga: GenT[Parser], gb: GenT[Parser0]): Gen[GenT[Parser]] = {
+  def softProduct10(ga: GenT[Parser], gb: GenT[Parser0]): Gen[GenT[Parser]] = {
     implicit val ca: Cogen[ga.A] = ga.cogen
     implicit val cb: Cogen[gb.A] = gb.cogen
     Gen.oneOf(
@@ -491,7 +491,7 @@ object ParserGen {
         Gen.frequency(
           (1, Gen.zip(rec, rec).flatMap { case (g1, g2) => product(g1, g2) }),
           (1, Gen.zip(rec, gen0).flatMap { case (g1, g2) => product10(g1, g2) }),
-          (1, Gen.zip(rec, gen0).flatMap { case (g1, g2) => softProduct(g1, g2) }),
+          (1, Gen.zip(rec, gen0).flatMap { case (g1, g2) => softProduct10(g1, g2) }),
           (1, Gen.zip(rec, rec, pures).flatMap { case (g1, g2, p) => orElse(g1, g2, p) })
         )
       )
@@ -1301,7 +1301,7 @@ class ParserTest extends munit.ScalaCheckSuite {
   property("(a1.soft ~ b) == softProduct(a, b)") {
     forAll(ParserGen.gen, ParserGen.gen0, Arbitrary.arbitrary[String]) { (a, b, str) =>
       val left1 = a.fa.soft ~ b.fa
-      val right1 = Parser.softProduct(a.fa, b.fa)
+      val right1 = Parser.softProduct10(a.fa, b.fa)
       assertEquals(left1.parse(str), right1.parse(str))
 
       val left2 = b.fa.soft ~ a.fa
@@ -1310,7 +1310,7 @@ class ParserTest extends munit.ScalaCheckSuite {
 
       assertEquals(
         (a.fa.soft *> b.fa).parse(str),
-        Parser.softProduct(a.fa.void, b.fa).map(_._2).parse(str)
+        Parser.softProduct10(a.fa.void, b.fa).map(_._2).parse(str)
       )
       assertEquals(
         (b.fa.with1.soft <* a.fa).parse(str),

--- a/core/shared/src/test/scala/cats/parse/ParserTest.scala
+++ b/core/shared/src/test/scala/cats/parse/ParserTest.scala
@@ -457,7 +457,7 @@ object ParserGen {
       (1, rec.flatMap(mapped(_))),
       (1, rec.flatMap(selected(_))),
       (1, tailRecM(Gen.lzy(gen))),
-      (1, Gen.choose(0, 10).map { l => GenT(Parser0.length(l)) }),
+      (1, Gen.choose(0, 10).map { l => GenT(Parser0.length0(l)) }),
       (1, flatMapped(rec)),
       (1, Gen.zip(rec, rec).flatMap { case (g1, g2) => product(g1, g2) }),
       (1, Gen.zip(rec, rec).flatMap { case (g1, g2) => softProduct(g1, g2) }),
@@ -483,7 +483,7 @@ object ParserGen {
       (1, rec.flatMap(mapped1(_))),
       (1, flatMapped1(gen0, rec)),
       (1, tailRecM1(rec)),
-      (1, Gen.choose(1, 10).map { l => GenT(Parser0.length1(l)) }),
+      (1, Gen.choose(1, 10).map { l => GenT(Parser0.length(l)) }),
       (
         2,
         Gen.frequency(
@@ -612,16 +612,16 @@ class ParserTest extends munit.ScalaCheckSuite {
     }
   }
 
-  property("Parser0.length succeeds when the string is long enough") {
+  property("Parser0.length0 succeeds when the string is long enough") {
     forAll { (s: String, len: Int) =>
       if (len < 1) {
         intercept[IllegalArgumentException] {
-          Parser0.length1(len)
+          Parser0.length(len)
         }
-        assertEquals(Parser0.length(len).parse(s), Right((s, "")))
+        assertEquals(Parser0.length0(len).parse(s), Right((s, "")))
       } else {
-        val pa = Parser0.length(len)
-        val pa1 = Parser0.length1(len)
+        val pa = Parser0.length0(len)
+        val pa1 = Parser0.length(len)
 
         val res = pa.parse(s)
         val res1 = pa1.parse(s)
@@ -808,7 +808,7 @@ class ParserTest extends munit.ScalaCheckSuite {
           off = if (s1 == "") str.length else str.indexOf(s1)
           // make the offsets the same
           sfix = " " * off + s1
-          p3 = (Parser0.length(off) ~ p2.fa).map(_._2)
+          p3 = (Parser0.length0(off) ~ p2.fa).map(_._2)
           pair2 <- p3.parse(sfix)
           (s2, a2) = pair2
         } yield (s2, (a1, a2))
@@ -833,7 +833,7 @@ class ParserTest extends munit.ScalaCheckSuite {
           off = if (s1 == "") str.length else str.indexOf(s1)
           // make the offsets the same
           sfix = " " * off + s1
-          p3 = Parser0.length(off) *> p2.fa
+          p3 = Parser0.length0(off) *> p2.fa
           pair2 <- p3.parse(sfix)
           (s2, a2) = pair2
         } yield (s2, (a1, a2))
@@ -854,7 +854,7 @@ class ParserTest extends munit.ScalaCheckSuite {
           off = if (s1 == "") str.length else str.indexOf(s1)
           // make the offsets the same
           sfix = " " * off + s1
-          p3 = Parser0.length(off) *> p2.fa
+          p3 = Parser0.length0(off) *> p2.fa
           pair2 <- p3.parse(sfix)
           (s2, a2) = pair2
         } yield (s2, (a1, a2))
@@ -875,7 +875,7 @@ class ParserTest extends munit.ScalaCheckSuite {
           off = if (s1 == "") str.length else str.indexOf(s1)
           // make the offsets the same
           sfix = " " * off + s1
-          p3 = (Parser0.length(off) ~ p2.fa).map(_._2)
+          p3 = (Parser0.length0(off) ~ p2.fa).map(_._2)
           pair2 <- (p3.parse(sfix).leftMap {
             case Parser0.Error(fidx, errs) if (fidx == off) => Parser0.Error(0, errs)
             case notEps2 => notEps2
@@ -899,7 +899,7 @@ class ParserTest extends munit.ScalaCheckSuite {
           off = if (s1 == "") str.length else str.indexOf(s1)
           // make the offsets the same
           sfix = " " * off + s1
-          p3 = (Parser0.length(off) ~ p2.fa).map(_._2)
+          p3 = (Parser0.length0(off) ~ p2.fa).map(_._2)
           pair2 <- (p3.parse(sfix).leftMap {
             case Parser0.Error(fidx, errs) if (fidx == off) => Parser0.Error(0, errs)
             case notEps2 => notEps2
@@ -923,7 +923,7 @@ class ParserTest extends munit.ScalaCheckSuite {
           off = if (s1 == "") str.length else str.indexOf(s1)
           // make the offsets the same
           sfix = " " * off + s1
-          p3 = (Parser0.length(off) ~ p2.fa).map(_._2)
+          p3 = (Parser0.length0(off) ~ p2.fa).map(_._2)
           pair2 <- (p3.parse(sfix).leftMap {
             case Parser0.Error(fidx, errs) if (fidx == off) => Parser0.Error(0, errs)
             case notEps2 => notEps2
@@ -941,7 +941,7 @@ class ParserTest extends munit.ScalaCheckSuite {
   }
 
   test("partial parse fails in rep0") {
-    val partial = Parser0.length1(1) ~ Parser0.fail
+    val partial = Parser0.length(1) ~ Parser0.fail
     // we can't return empty list here
     assert(partial.rep0.parse("foo").isLeft)
 
@@ -1323,7 +1323,7 @@ class ParserTest extends munit.ScalaCheckSuite {
     forAll(ParserGen.gen0, Arbitrary.arbitrary[String]) { (a, str) =>
       val p = Parser0.until(a.fa) *> a.fa
       def loopMatch(cnt: Int): Option[(String, a.A)] =
-        (Parser0.length(cnt) *> a.fa).parse(str) match {
+        (Parser0.length0(cnt) *> a.fa).parse(str) match {
           case Right(res) => Some(res)
           case Left(_) if cnt > str.length => None
           case _ => loopMatch(cnt + 1)

--- a/core/shared/src/test/scala/cats/parse/ParserTest.scala
+++ b/core/shared/src/test/scala/cats/parse/ParserTest.scala
@@ -132,10 +132,10 @@ object ParserGen {
   def string(g: GenT[Parser]): GenT[Parser] =
     GenT(Parser0.string(g.fa))
 
-  def backtrack(g: GenT[Parser0]): GenT[Parser0] =
+  def backtrack0(g: GenT[Parser0]): GenT[Parser0] =
     GenT(g.fa.backtrack)(g.cogen)
 
-  def backtrack1(g: GenT[Parser]): GenT[Parser] =
+  def backtrack(g: GenT[Parser]): GenT[Parser] =
     GenT(g.fa.backtrack)(g.cogen)
 
   def defer0(g: GenT[Parser0]): GenT[Parser0] =
@@ -450,7 +450,7 @@ object ParserGen {
       (1, failWith),
       (1, rec.map(void0(_))),
       (1, rec.map(string0(_))),
-      (1, rec.map(backtrack(_))),
+      (1, rec.map(backtrack0(_))),
       (1, rec.map(defer0(_))),
       (1, rec.map { gen => GenT(!gen.fa) }),
       (1, Gen.lzy(gen.map(rep0(_)))),
@@ -476,7 +476,7 @@ object ParserGen {
       (1, Gen.choose(Char.MinValue, Char.MaxValue).map { c => GenT(Parser0.char(c)) }),
       (2, rec.map(void(_))),
       (2, rec.map(string(_))),
-      (2, rec.map(backtrack1(_))),
+      (2, rec.map(backtrack(_))),
       (1, rec.map(defer(_))),
       (1, rec.map(rep(_))),
       (1, selected1(rec, gen0)),

--- a/core/shared/src/test/scala/cats/parse/ParserTest.scala
+++ b/core/shared/src/test/scala/cats/parse/ParserTest.scala
@@ -160,7 +160,9 @@ object ParserGen {
     Gen.oneOf(
       GenT[Parser0, (ga.A, gb.A)](FlatMap[Parser0].product(ga.fa, gb.fa)),
       GenT[Parser0, (ga.A, gb.A)](FlatMap[Parser0].map2(ga.fa, gb.fa)((_, _))),
-      GenT[Parser0, (ga.A, gb.A)](FlatMap[Parser0].map2Eval(ga.fa, Eval.later(gb.fa))((_, _)).value),
+      GenT[Parser0, (ga.A, gb.A)](
+        FlatMap[Parser0].map2Eval(ga.fa, Eval.later(gb.fa))((_, _)).value
+      ),
       GenT[Parser0, (ga.A, gb.A)](FlatMap[Parser0].map2Eval(ga.fa, Eval.now(gb.fa))((_, _)).value)
     )
   }
@@ -745,7 +747,9 @@ class ParserTest extends munit.ScalaCheckSuite {
 
   property("oneOf0 same as foldLeft(fail)(_.orElse0(_))") {
     forAll(Gen.listOf(ParserGen.gen0), Arbitrary.arbitrary[String]) { (genP1, str) =>
-      val oneOfImpl = genP1.foldLeft(Parser.fail: Parser0[Any]) { (leftp, p) => leftp.orElse0(p.fa) }
+      val oneOfImpl = genP1.foldLeft(Parser.fail: Parser0[Any]) { (leftp, p) =>
+        leftp.orElse0(p.fa)
+      }
 
       assertEquals(oneOfImpl.parse(str), Parser.oneOf0(genP1.map(_.fa)).parse(str))
     }

--- a/core/shared/src/test/scala/cats/parse/ParserTest.scala
+++ b/core/shared/src/test/scala/cats/parse/ParserTest.scala
@@ -76,61 +76,61 @@ object ParserGen {
 
   val expect0: Gen[GenT[Parser0]] =
     Arbitrary.arbitrary[String].map { str =>
-      GenT(Parser0.string0(str))
+      GenT(Parser.string0(str))
     }
 
   val ignoreCase0: Gen[GenT[Parser0]] =
     Arbitrary.arbitrary[String].map { str =>
-      GenT(Parser0.ignoreCase0(str))
+      GenT(Parser.ignoreCase0(str))
     }
 
   val charIn0: Gen[GenT[Parser0]] =
     Gen.oneOf(
       Arbitrary.arbitrary[List[Char]].map { cs =>
-        GenT(Parser0.charIn(cs): Parser0[Char])
+        GenT(Parser.charIn(cs): Parser0[Char])
       },
-      Gen.const(GenT(Parser0.anyChar: Parser0[Char]))
+      Gen.const(GenT(Parser.anyChar: Parser0[Char]))
     )
 
   val charIn: Gen[GenT[Parser]] =
     Gen.oneOf(
       Arbitrary.arbitrary[List[Char]].map { cs =>
-        GenT(Parser0.charIn(cs))
+        GenT(Parser.charIn(cs))
       },
-      Gen.const(GenT(Parser0.anyChar))
+      Gen.const(GenT(Parser.anyChar))
     )
 
   val expect1: Gen[GenT[Parser]] =
     Arbitrary.arbitrary[String].map { str =>
-      if (str.isEmpty) GenT(Parser0.fail: Parser[Unit])
-      else GenT(Parser0.string(str))
+      if (str.isEmpty) GenT(Parser.fail: Parser[Unit])
+      else GenT(Parser.string(str))
     }
 
   val ignoreCase: Gen[GenT[Parser]] =
     Arbitrary.arbitrary[String].map { str =>
-      if (str.isEmpty) GenT(Parser0.fail: Parser[Unit])
-      else GenT(Parser0.ignoreCase(str))
+      if (str.isEmpty) GenT(Parser.fail: Parser[Unit])
+      else GenT(Parser.ignoreCase(str))
     }
 
   val fail: Gen[GenT[Parser0]] =
-    Gen.const(GenT(Parser0.fail: Parser0[Unit]))
+    Gen.const(GenT(Parser.fail: Parser0[Unit]))
 
   val failWith: Gen[GenT[Parser0]] =
     Arbitrary.arbitrary[String].map { str =>
-      GenT(Parser0.failWith[Unit](str))
+      GenT(Parser.failWith[Unit](str))
     }
 
   def void0(g: GenT[Parser0]): GenT[Parser0] =
-    GenT(Parser0.void0(g.fa))
+    GenT(Parser.void0(g.fa))
 
   def void(g: GenT[Parser]): GenT[Parser] =
-    GenT(Parser0.void(g.fa))
+    GenT(Parser.void(g.fa))
 
   def string0(g: GenT[Parser0]): GenT[Parser0] =
-    GenT(Parser0.string0(g.fa))
+    GenT(Parser.string0(g.fa))
 
   def string(g: GenT[Parser]): GenT[Parser] =
-    GenT(Parser0.string(g.fa))
+    GenT(Parser.string(g.fa))
 
   def backtrack0(g: GenT[Parser0]): GenT[Parser0] =
     GenT(g.fa.backtrack)(g.cogen)
@@ -190,10 +190,10 @@ object ParserGen {
     implicit val ca: Cogen[ga.A] = ga.cogen
     implicit val cb: Cogen[gb.A] = gb.cogen
     Gen.oneOf(
-      GenT[Parser, (ga.A, gb.A)](Parser0.product(ga.fa, gb.fa)),
+      GenT[Parser, (ga.A, gb.A)](Parser.product(ga.fa, gb.fa)),
       GenT[Parser, ga.A](ga.fa <* gb.fa),
       GenT[Parser, gb.A](ga.fa *> gb.fa),
-      GenT[Parser, (ga.A, ga.A)](Parser0.product(ga.fa, ga.fa))
+      GenT[Parser, (ga.A, ga.A)](Parser.product(ga.fa, ga.fa))
     )
   }
 
@@ -266,7 +266,7 @@ object ParserGen {
         }
 
       Gen.zip(genPR, gfn).map { case (pab, fn) =>
-        GenT(Parser0.select0(pab)(fn))(genRes2.cogen)
+        GenT(Parser.select0(pab)(fn))(genRes2.cogen)
       }
     }
 
@@ -361,7 +361,7 @@ object ParserGen {
         }
 
       Gen.zip(genPR1, gfn).map { case (pab, fn) =>
-        GenT(Parser0.select(pab)(fn))(genRes2.cogen)
+        GenT(Parser.select(pab)(fn))(genRes2.cogen)
       }
     }
 
@@ -439,13 +439,13 @@ object ParserGen {
         pures
           .flatMap(_.toId)
           .map(_.transform(new FunctionK[Id, Parser0] {
-            def apply[A](g: Id[A]): Parser0[A] = Parser0.pure(g)
+            def apply[A](g: Id[A]): Parser0[A] = Parser.pure(g)
           }))
       ),
       (5, expect0),
       (1, ignoreCase0),
       (5, charIn0),
-      (1, Gen.oneOf(GenT(Parser0.start), GenT(Parser0.end), GenT(Parser0.index))),
+      (1, Gen.oneOf(GenT(Parser.start), GenT(Parser.end), GenT(Parser.index))),
       (1, fail),
       (1, failWith),
       (1, rec.map(void0(_))),
@@ -457,7 +457,7 @@ object ParserGen {
       (1, rec.flatMap(mapped(_))),
       (1, rec.flatMap(selected(_))),
       (1, tailRecM(Gen.lzy(gen))),
-      (1, Gen.choose(0, 10).map { l => GenT(Parser0.length0(l)) }),
+      (1, Gen.choose(0, 10).map { l => GenT(Parser.length0(l)) }),
       (1, flatMapped(rec)),
       (1, Gen.zip(rec, rec).flatMap { case (g1, g2) => product0(g1, g2) }),
       (1, Gen.zip(rec, rec).flatMap { case (g1, g2) => softProduct0(g1, g2) }),
@@ -473,7 +473,7 @@ object ParserGen {
       (8, expect1),
       (2, ignoreCase),
       (8, charIn),
-      (1, Gen.choose(Char.MinValue, Char.MaxValue).map { c => GenT(Parser0.char(c)) }),
+      (1, Gen.choose(Char.MinValue, Char.MaxValue).map { c => GenT(Parser.char(c)) }),
       (2, rec.map(void(_))),
       (2, rec.map(string(_))),
       (2, rec.map(backtrack(_))),
@@ -483,7 +483,7 @@ object ParserGen {
       (1, rec.flatMap(mapped1(_))),
       (1, flatMapped1(gen0, rec)),
       (1, tailRecM1(rec)),
-      (1, Gen.choose(1, 10).map { l => GenT(Parser0.length(l)) }),
+      (1, Gen.choose(1, 10).map { l => GenT(Parser.length(l)) }),
       (
         2,
         Gen.frequency(
@@ -543,15 +543,15 @@ class ParserTest extends munit.ScalaCheckSuite {
     }
 
   test("pure works") {
-    parseTest(Parser0.pure(42), "anything", 42)
+    parseTest(Parser.pure(42), "anything", 42)
   }
 
-  val fooP = Parser0.string("foo")
-  val barP = Parser0.string("bar")
-  val fooCIP = Parser0.ignoreCase("foo")
-  val cCIP = Parser0.ignoreCase("a")
-  val cCIP1 = Parser0.ignoreCaseChar('a')
-  val abcCI = Parser0.ignoreCaseCharIn('a', 'b', 'c')
+  val fooP = Parser.string("foo")
+  val barP = Parser.string("bar")
+  val fooCIP = Parser.ignoreCase("foo")
+  val cCIP = Parser.ignoreCase("a")
+  val cCIP1 = Parser.ignoreCaseChar('a')
+  val abcCI = Parser.ignoreCaseCharIn('a', 'b', 'c')
 
   test("string tests") {
     parseTest(fooP, "foobar", ())
@@ -571,14 +571,14 @@ class ParserTest extends munit.ScalaCheckSuite {
     parseTest(abcCI, "C", 'C')
     parseFail(abcCI, "D")
 
-    parseTest(Parser0.oneOf(fooP :: barP :: Nil), "bar", ())
-    parseTest(Parser0.oneOf(fooP :: barP :: Nil), "foo", ())
+    parseTest(Parser.oneOf(fooP :: barP :: Nil), "bar", ())
+    parseTest(Parser.oneOf(fooP :: barP :: Nil), "foo", ())
   }
 
   test("product tests") {
-    parseTest(Parser0.product01(fooP, barP), "foobar", ((), ()))
-    parseTest(Parser0.product(fooP, barP), "foobar", ((), ()))
-    parseTest(Parser0.product0(fooP, barP), "foobar", ((), ()))
+    parseTest(Parser.product01(fooP, barP), "foobar", ((), ()))
+    parseTest(Parser.product(fooP, barP), "foobar", ((), ()))
+    parseTest(Parser.product0(fooP, barP), "foobar", ((), ()))
   }
 
   property("Parser0 on success replaces parsed value") {
@@ -591,19 +591,19 @@ class ParserTest extends munit.ScalaCheckSuite {
     }
   }
 
-  property("Parser0.start and end work") {
+  property("Parser.start and end work") {
     forAll { (s: String) =>
       if (s.isEmpty) {
         intercept[IllegalArgumentException] {
-          Parser0.string(s)
+          Parser.string(s)
         }
       } else {
-        val pa = Parser0.string(s)
-        assertEquals((Parser0.start ~ pa ~ Parser0.end).void.parse(s), Right(("", ())))
-        assert((pa ~ Parser0.start).parse(s).isLeft)
-        assert((Parser0.end ~ pa).parse(s).isLeft)
+        val pa = Parser.string(s)
+        assertEquals((Parser.start ~ pa ~ Parser.end).void.parse(s), Right(("", ())))
+        assert((pa ~ Parser.start).parse(s).isLeft)
+        assert((Parser.end ~ pa).parse(s).isLeft)
         assertEquals(
-          (Parser0.index ~ pa ~ Parser0.index).map { case ((s, _), e) => e - s }.parse(s),
+          (Parser.index ~ pa ~ Parser.index).map { case ((s, _), e) => e - s }.parse(s),
           Right(("", s.length))
         )
       }
@@ -612,16 +612,16 @@ class ParserTest extends munit.ScalaCheckSuite {
     }
   }
 
-  property("Parser0.length0 succeeds when the string is long enough") {
+  property("Parser.length0 succeeds when the string is long enough") {
     forAll { (s: String, len: Int) =>
       if (len < 1) {
         intercept[IllegalArgumentException] {
-          Parser0.length(len)
+          Parser.length(len)
         }
-        assertEquals(Parser0.length0(len).parse(s), Right((s, "")))
+        assertEquals(Parser.length0(len).parse(s), Right((s, "")))
       } else {
-        val pa = Parser0.length0(len)
-        val pa1 = Parser0.length(len)
+        val pa = Parser.length0(len)
+        val pa1 = Parser.length(len)
 
         val res = pa.parse(s)
         val res1 = pa1.parse(s)
@@ -634,7 +634,7 @@ class ParserTest extends munit.ScalaCheckSuite {
               assertEquals(s.take(len), first)
               assertEquals(s.drop(len), rest)
             } else fail(s"expected to not parse: $rest, $first")
-          case Left(Parser0.Error(0, NonEmptyList(Parser0.Expectation.Length(off, l, a), Nil))) =>
+          case Left(Parser.Error(0, NonEmptyList(Parser.Expectation.Length(off, l, a), Nil))) =>
             assertEquals(off, 0)
             assertEquals(l, len)
             assertEquals(a, s.length)
@@ -691,8 +691,8 @@ class ParserTest extends munit.ScalaCheckSuite {
   property("oneOf0 nesting doesn't change results") {
     forAll(Gen.listOf(ParserGen.gen0), Gen.listOf(ParserGen.gen0), Arbitrary.arbitrary[String]) {
       (genP1, genP2, str) =>
-        val oneOf = Parser0.oneOf0((genP1 ::: genP2).map(_.fa))
-        val oneOf2 = Parser0.oneOf0(genP1.map(_.fa)).orElse0(Parser0.oneOf0(genP2.map(_.fa)))
+        val oneOf = Parser.oneOf0((genP1 ::: genP2).map(_.fa))
+        val oneOf2 = Parser.oneOf0(genP1.map(_.fa)).orElse0(Parser.oneOf0(genP2.map(_.fa)))
 
         assertEquals(oneOf.parse(str), oneOf2.parse(str))
     }
@@ -701,20 +701,20 @@ class ParserTest extends munit.ScalaCheckSuite {
   property("oneOf nesting doesn't change results") {
     forAll(Gen.listOf(ParserGen.gen), Gen.listOf(ParserGen.gen), Arbitrary.arbitrary[String]) {
       (genP1, genP2, str) =>
-        val oneOf = Parser0.oneOf((genP1 ::: genP2).map(_.fa))
-        val oneOf2 = Parser0
+        val oneOf = Parser.oneOf((genP1 ::: genP2).map(_.fa))
+        val oneOf2 = Parser
           .oneOf(genP1.map(_.fa))
           .orElse(
-            Parser0.oneOf(genP2.map(_.fa))
+            Parser.oneOf(genP2.map(_.fa))
           )
 
         assertEquals(oneOf.parse(str), oneOf2.parse(str))
     }
   }
 
-  def orElse[A](p1: Parser0[A], p2: Parser0[A], str: String): Either[Parser0.Error, (String, A)] = {
-    if (p1 == Parser0.Fail) p2.parse(str)
-    else if (p2 == Parser0.Fail) p1.parse(str)
+  def orElse[A](p1: Parser0[A], p2: Parser0[A], str: String): Either[Parser.Error, (String, A)] = {
+    if (p1 == Parser.Fail) p2.parse(str)
+    else if (p2 == Parser.Fail) p1.parse(str)
     else
       p1.parse(str) match {
         case left @ Left(err) =>
@@ -723,7 +723,7 @@ class ParserTest extends munit.ScalaCheckSuite {
               .leftMap { err1 =>
                 if (err1.failedAtOffset == 0) {
                   val errs = err.expected ::: err1.expected
-                  Parser0.Error(err1.failedAtOffset, Parser0.Expectation.unify(errs))
+                  Parser.Error(err1.failedAtOffset, Parser.Expectation.unify(errs))
                 } else err1
               }
           } else left
@@ -745,24 +745,24 @@ class ParserTest extends munit.ScalaCheckSuite {
 
   property("oneOf0 same as foldLeft(fail)(_.orElse0(_))") {
     forAll(Gen.listOf(ParserGen.gen0), Arbitrary.arbitrary[String]) { (genP1, str) =>
-      val oneOfImpl = genP1.foldLeft(Parser0.fail: Parser0[Any]) { (leftp, p) => leftp.orElse0(p.fa) }
+      val oneOfImpl = genP1.foldLeft(Parser.fail: Parser0[Any]) { (leftp, p) => leftp.orElse0(p.fa) }
 
-      assertEquals(oneOfImpl.parse(str), Parser0.oneOf0(genP1.map(_.fa)).parse(str))
+      assertEquals(oneOfImpl.parse(str), Parser.oneOf0(genP1.map(_.fa)).parse(str))
     }
   }
 
   property("oneOf same as foldLeft(fail)(_.orElse(_))") {
     forAll(Gen.listOf(ParserGen.gen), Arbitrary.arbitrary[String]) { (genP1, str) =>
-      val oneOfImpl = genP1.foldLeft(Parser0.fail[Any]) { (leftp, p) => leftp.orElse(p.fa) }
+      val oneOfImpl = genP1.foldLeft(Parser.fail[Any]) { (leftp, p) => leftp.orElse(p.fa) }
 
-      assertEquals(oneOfImpl.parse(str), Parser0.oneOf(genP1.map(_.fa)).parse(str))
+      assertEquals(oneOfImpl.parse(str), Parser.oneOf(genP1.map(_.fa)).parse(str))
     }
   }
 
   property("string can be recovered with index") {
     forAll(ParserGen.gen0, Arbitrary.arbitrary[String]) { (genP, str) =>
       val r1 = genP.fa.string.parse(str)
-      val r2 = (genP.fa ~ Parser0.index).map { case (_, end) => str.substring(0, end) }.parse(str)
+      val r2 = (genP.fa ~ Parser.index).map { case (_, end) => str.substring(0, end) }.parse(str)
 
       assertEquals(r1.toOption, r2.toOption)
     }
@@ -770,7 +770,7 @@ class ParserTest extends munit.ScalaCheckSuite {
 
   property("backtrack orElse pure always succeeds") {
     forAll(ParserGen.gen0, Arbitrary.arbitrary[String]) { (genP, str) =>
-      val p1 = genP.fa.backtrack.orElse0(Parser0.pure(())): Parser0[Any]
+      val p1 = genP.fa.backtrack.orElse0(Parser.pure(())): Parser0[Any]
 
       assert(p1.parse(str).isRight)
     }
@@ -808,7 +808,7 @@ class ParserTest extends munit.ScalaCheckSuite {
           off = if (s1 == "") str.length else str.indexOf(s1)
           // make the offsets the same
           sfix = " " * off + s1
-          p3 = (Parser0.length0(off) ~ p2.fa).map(_._2)
+          p3 = (Parser.length0(off) ~ p2.fa).map(_._2)
           pair2 <- p3.parse(sfix)
           (s2, a2) = pair2
         } yield (s2, (a1, a2))
@@ -833,7 +833,7 @@ class ParserTest extends munit.ScalaCheckSuite {
           off = if (s1 == "") str.length else str.indexOf(s1)
           // make the offsets the same
           sfix = " " * off + s1
-          p3 = Parser0.length0(off) *> p2.fa
+          p3 = Parser.length0(off) *> p2.fa
           pair2 <- p3.parse(sfix)
           (s2, a2) = pair2
         } yield (s2, (a1, a2))
@@ -854,7 +854,7 @@ class ParserTest extends munit.ScalaCheckSuite {
           off = if (s1 == "") str.length else str.indexOf(s1)
           // make the offsets the same
           sfix = " " * off + s1
-          p3 = Parser0.length0(off) *> p2.fa
+          p3 = Parser.length0(off) *> p2.fa
           pair2 <- p3.parse(sfix)
           (s2, a2) = pair2
         } yield (s2, (a1, a2))
@@ -875,9 +875,9 @@ class ParserTest extends munit.ScalaCheckSuite {
           off = if (s1 == "") str.length else str.indexOf(s1)
           // make the offsets the same
           sfix = " " * off + s1
-          p3 = (Parser0.length0(off) ~ p2.fa).map(_._2)
+          p3 = (Parser.length0(off) ~ p2.fa).map(_._2)
           pair2 <- (p3.parse(sfix).leftMap {
-            case Parser0.Error(fidx, errs) if (fidx == off) => Parser0.Error(0, errs)
+            case Parser.Error(fidx, errs) if (fidx == off) => Parser.Error(0, errs)
             case notEps2 => notEps2
           })
           (s2, a2) = pair2
@@ -899,9 +899,9 @@ class ParserTest extends munit.ScalaCheckSuite {
           off = if (s1 == "") str.length else str.indexOf(s1)
           // make the offsets the same
           sfix = " " * off + s1
-          p3 = (Parser0.length0(off) ~ p2.fa).map(_._2)
+          p3 = (Parser.length0(off) ~ p2.fa).map(_._2)
           pair2 <- (p3.parse(sfix).leftMap {
-            case Parser0.Error(fidx, errs) if (fidx == off) => Parser0.Error(0, errs)
+            case Parser.Error(fidx, errs) if (fidx == off) => Parser.Error(0, errs)
             case notEps2 => notEps2
           })
           (s2, a2) = pair2
@@ -923,9 +923,9 @@ class ParserTest extends munit.ScalaCheckSuite {
           off = if (s1 == "") str.length else str.indexOf(s1)
           // make the offsets the same
           sfix = " " * off + s1
-          p3 = (Parser0.length0(off) ~ p2.fa).map(_._2)
+          p3 = (Parser.length0(off) ~ p2.fa).map(_._2)
           pair2 <- (p3.parse(sfix).leftMap {
-            case Parser0.Error(fidx, errs) if (fidx == off) => Parser0.Error(0, errs)
+            case Parser.Error(fidx, errs) if (fidx == off) => Parser.Error(0, errs)
             case notEps2 => notEps2
           })
           (s2, a2) = pair2
@@ -936,16 +936,16 @@ class ParserTest extends munit.ScalaCheckSuite {
   }
 
   test("range messages seem to work") {
-    val pa = Parser0.charIn('0' to '9')
+    val pa = Parser.charIn('0' to '9')
     assertEquals(pa.parse("z").toString, "Left(Error(0,NonEmptyList(InRange(0,0,9))))")
   }
 
   test("partial parse fails in rep0") {
-    val partial = Parser0.length(1) ~ Parser0.fail
+    val partial = Parser.length(1) ~ Parser.fail
     // we can't return empty list here
     assert(partial.rep0.parse("foo").isLeft)
 
-    val p2 = Parser0.string("f").orElse((Parser0.string("boo") ~ Parser0.string("p")).void)
+    val p2 = Parser.string("f").orElse((Parser.string("boo") ~ Parser.string("p")).void)
     assert(p2.rep.parse("fboop").isRight)
     assert(p2.rep(2).parse("fboop").isRight)
     assert(p2.rep(3).parse("fboop").isLeft)
@@ -956,7 +956,7 @@ class ParserTest extends munit.ScalaCheckSuite {
     var cnt = 0
     val res = Defer[Parser0].defer {
       cnt += 1
-      Parser0.string("foo")
+      Parser.string("foo")
     }
     assert(cnt == 0)
     assert(res.parse("foo") == Right(("", ())))
@@ -969,7 +969,7 @@ class ParserTest extends munit.ScalaCheckSuite {
     var cnt = 0
     val res = Defer[Parser].defer {
       cnt += 1
-      Parser0.string("foo")
+      Parser.string("foo")
     }
     assert(cnt == 0)
     assert(res.parse("foo") == Right(("", ())))
@@ -981,8 +981,8 @@ class ParserTest extends munit.ScalaCheckSuite {
   property("charIn matches charWhere") {
     forAll { (cs: List[Char], str: String) =>
       val cset = cs.toSet
-      val p1 = Parser0.charIn(cs)
-      val p2 = Parser0.charWhere(cset)
+      val p1 = Parser.charIn(cs)
+      val p2 = Parser.charWhere(cset)
 
       assertEquals(p1.parse(str), p2.parse(str))
     }
@@ -991,20 +991,20 @@ class ParserTest extends munit.ScalaCheckSuite {
   property("charIn matches charIn varargs") {
     forAll { (c0: Char, cs0: List[Char], str: String) =>
       val cs = c0 :: cs0
-      val p1 = Parser0.charIn(cs)
-      val p2 = Parser0.charIn(c0, cs0: _*)
+      val p1 = Parser.charIn(cs)
+      val p2 = Parser.charIn(c0, cs0: _*)
 
       assertEquals(p1.parse(str), p2.parse(str))
     }
   }
 
-  property("Parser0.end gives the right error") {
+  property("Parser.end gives the right error") {
     forAll { (str: String) =>
-      Parser0.end.parse(str) match {
+      Parser.end.parse(str) match {
         case Right((rest, _)) =>
           assertEquals(str, "")
           assertEquals(rest, "")
-        case Left(Parser0.Error(0, NonEmptyList(Parser0.Expectation.EndOfString(off, len), Nil))) =>
+        case Left(Parser.Error(0, NonEmptyList(Parser.Expectation.EndOfString(off, len), Nil))) =>
           assertEquals(off, 0)
           assertEquals(len, str.length)
         case other =>
@@ -1019,7 +1019,7 @@ class ParserTest extends munit.ScalaCheckSuite {
         Defer[Parser0].fix[List[A]] { tail =>
           (pa ~ tail)
             .map { case (h, t) => h :: t }
-            .orElse0(Parser0.pure(Nil))
+            .orElse0(Parser.pure(Nil))
         }
 
       val lst1 = rep0(genP.fa)
@@ -1038,8 +1038,8 @@ class ParserTest extends munit.ScalaCheckSuite {
           .rep(min)
           .map(_.toList)
           .orElse0(
-            if (min == 0) Parser0.pure(Nil)
-            else Parser0.fail
+            if (min == 0) Parser.pure(Nil)
+            else Parser.fail
           )
 
         assertEquals(repA.parse(str), repB.parse(str))
@@ -1050,13 +1050,13 @@ class ParserTest extends munit.ScalaCheckSuite {
     forAll(ParserGen.gen, Gen.choose(0, Int.MaxValue), Arbitrary.arbitrary[String]) {
       (genP, min0, str) =>
         val min = min0 & Int.MaxValue
-        val p1a = Parser0.rep0Sep(genP.fa, min = min, sep = Parser0.unit)
+        val p1a = Parser.rep0Sep(genP.fa, min = min, sep = Parser.unit)
         val p1b = genP.fa.rep0(min = min)
 
         assertEquals(p1a.parse(str), p1b.parse(str))
 
         val min1 = if (min < 1) 1 else min
-        val p2a = Parser0.repSep(genP.fa, min = min1, sep = Parser0.unit)
+        val p2a = Parser.repSep(genP.fa, min = min1, sep = Parser.unit)
         val p2b = genP.fa.rep(min = min1)
 
         assertEquals(p2a.parse(str), p2b.parse(str))
@@ -1067,7 +1067,7 @@ class ParserTest extends munit.ScalaCheckSuite {
     forAll(ParserGen.gen, Arbitrary.arbitrary[String]) { (genP, str) =>
       assertEquals(
         genP.fa.parse(str),
-        Parser0.repSep(genP.fa, 1, Parser0.fail).parse(str).map { case (rest, nel) =>
+        Parser.repSep(genP.fa, 1, Parser.fail).parse(str).map { case (rest, nel) =>
           (rest, nel.head)
         }
       )
@@ -1080,12 +1080,12 @@ class ParserTest extends munit.ScalaCheckSuite {
       Arbitrary.arbitrary[String]
     ) { (chars, str) =>
       val pred = chars.toSet
-      val p1a = Parser0.charsWhile0(pred)
-      val p1b = Parser0.charWhere(pred).rep0.string
+      val p1a = Parser.charsWhile0(pred)
+      val p1b = Parser.charWhere(pred).rep0.string
       assertEquals(p1a.parse(str), p1b.parse(str))
 
-      val p2a = Parser0.charsWhile(pred)
-      val p2b = Parser0.charWhere(pred).rep.string
+      val p2a = Parser.charsWhile(pred)
+      val p2b = Parser.charWhere(pred).rep.string
       assertEquals(p2a.parse(str), p2b.parse(str))
     }
   }
@@ -1154,7 +1154,7 @@ class ParserTest extends munit.ScalaCheckSuite {
   }
 
   test("charWhere(_ => true) == anyChar") {
-    assertEquals(Parser0.charWhere(_ => true), Parser0.anyChar)
+    assertEquals(Parser.charWhere(_ => true), Parser.anyChar)
   }
 
   property("with1 *> and with1 <* work as expected") {
@@ -1173,11 +1173,11 @@ class ParserTest extends munit.ScalaCheckSuite {
     forAll(ParserGen.gen, ParserGen.gen0, Arbitrary.arbitrary[String]) { (p1, p2, str) =>
       assertEquals(
         (p1.fa *> p2.fa).parse(str),
-        Parser0.product(p1.fa.void, p2.fa).map(_._2).parse(str)
+        Parser.product(p1.fa.void, p2.fa).map(_._2).parse(str)
       )
       assertEquals(
         (p1.fa <* p2.fa).parse(str),
-        Parser0.product(p1.fa, p2.fa.void).map(_._1).parse(str)
+        Parser.product(p1.fa, p2.fa.void).map(_._1).parse(str)
       )
     }
   }
@@ -1281,15 +1281,15 @@ class ParserTest extends munit.ScalaCheckSuite {
   property("(a.soft ~ b) == softProduct(a, b)") {
     forAll(ParserGen.gen0, ParserGen.gen0, Arbitrary.arbitrary[String]) { (a, b, str) =>
       val left = a.fa.soft ~ b.fa
-      val right = Parser0.softProduct0(a.fa, b.fa)
+      val right = Parser.softProduct0(a.fa, b.fa)
       assertEquals(left.parse(str), right.parse(str))
       assertEquals(
         (a.fa.soft *> b.fa).parse(str),
-        Parser0.softProduct0(a.fa.void, b.fa).map(_._2).parse(str)
+        Parser.softProduct0(a.fa.void, b.fa).map(_._2).parse(str)
       )
       assertEquals(
         (a.fa.soft <* b.fa).parse(str),
-        Parser0.softProduct0(a.fa, b.fa.void).map(_._1).parse(str)
+        Parser.softProduct0(a.fa, b.fa.void).map(_._1).parse(str)
       )
     }
   }
@@ -1297,33 +1297,33 @@ class ParserTest extends munit.ScalaCheckSuite {
   property("(a1.soft ~ b) == softProduct(a, b)") {
     forAll(ParserGen.gen, ParserGen.gen0, Arbitrary.arbitrary[String]) { (a, b, str) =>
       val left1 = a.fa.soft ~ b.fa
-      val right1 = Parser0.softProduct(a.fa, b.fa)
+      val right1 = Parser.softProduct(a.fa, b.fa)
       assertEquals(left1.parse(str), right1.parse(str))
 
       val left2 = b.fa.soft ~ a.fa
-      val right2 = Parser0.softProduct01(b.fa, a.fa)
+      val right2 = Parser.softProduct01(b.fa, a.fa)
       assertEquals(left2.parse(str), right2.parse(str))
 
       assertEquals(
         (a.fa.soft *> b.fa).parse(str),
-        Parser0.softProduct(a.fa.void, b.fa).map(_._2).parse(str)
+        Parser.softProduct(a.fa.void, b.fa).map(_._2).parse(str)
       )
       assertEquals(
         (b.fa.with1.soft <* a.fa).parse(str),
-        Parser0.softProduct01(b.fa, a.fa.void).map(_._1).parse(str)
+        Parser.softProduct01(b.fa, a.fa.void).map(_._1).parse(str)
       )
       assertEquals(
         (b.fa.with1.soft *> a.fa).parse(str),
-        Parser0.softProduct01(b.fa.void, a.fa).map(_._2).parse(str)
+        Parser.softProduct01(b.fa.void, a.fa).map(_._2).parse(str)
       )
     }
   }
 
-  property("Parser0.until is like a search") {
+  property("Parser.until is like a search") {
     forAll(ParserGen.gen0, Arbitrary.arbitrary[String]) { (a, str) =>
-      val p = Parser0.until0(a.fa) *> a.fa
+      val p = Parser.until0(a.fa) *> a.fa
       def loopMatch(cnt: Int): Option[(String, a.A)] =
-        (Parser0.length0(cnt) *> a.fa).parse(str) match {
+        (Parser.length0(cnt) *> a.fa).parse(str) match {
           case Right(res) => Some(res)
           case Left(_) if cnt > str.length => None
           case _ => loopMatch(cnt + 1)
@@ -1335,7 +1335,7 @@ class ParserTest extends munit.ScalaCheckSuite {
 
   property("parseAll law") {
     forAll(ParserGen.gen0, Arbitrary.arbitrary[String]) { (a, str) =>
-      val pall = (a.fa <* Parser0.end).parse(str).map(_._2)
+      val pall = (a.fa <* Parser.end).parse(str).map(_._2)
 
       assertEquals(a.fa.parseAll(str), pall)
     }
@@ -1459,15 +1459,15 @@ class ParserTest extends munit.ScalaCheckSuite {
   property("failWith returns the given error message") {
     forAll { (str: String, mes: String) =>
       assertEquals(
-        Parser0.failWith(mes).parse(str),
-        Left(Parser0.Error(0, NonEmptyList.of(Parser0.Expectation.FailWith(0, mes))))
+        Parser.failWith(mes).parse(str),
+        Left(Parser.Error(0, NonEmptyList.of(Parser.Expectation.FailWith(0, mes))))
       )
     }
   }
 
   property("failWith.? returns None") {
     forAll { (str: String, mes: String) =>
-      assertEquals(Parser0.failWith(mes).?.parse(str), Right((str, None)))
+      assertEquals(Parser.failWith(mes).?.parse(str), Right((str, None)))
     }
   }
 
@@ -1604,8 +1604,8 @@ class ParserTest extends munit.ScalaCheckSuite {
 
   property("!anyChar == end") {
     forAll { (str: String) =>
-      val left = !Parser0.anyChar
-      val right = Parser0.end
+      val left = !Parser.anyChar
+      val right = Parser.end
 
       val leftRes = left.parse(str).toOption
       val rightRes = right.parse(str).toOption
@@ -1615,8 +1615,8 @@ class ParserTest extends munit.ScalaCheckSuite {
 
   property("!fail == unit") {
     forAll { (str: String) =>
-      val left = !Parser0.fail
-      val right = Parser0.unit
+      val left = !Parser.fail
+      val right = Parser.unit
 
       val leftRes = left.parse(str)
       val rightRes = right.parse(str)
@@ -1626,8 +1626,8 @@ class ParserTest extends munit.ScalaCheckSuite {
 
   property("!pure(_) == fail") {
     forAll { (str: String, i: Int) =>
-      val left = !Parser0.pure(i)
-      val right = Parser0.fail
+      val left = !Parser.pure(i)
+      val right = Parser.fail
 
       val leftRes = left.parse(str).toOption
       val rightRes = right.parse(str).toOption
@@ -1637,14 +1637,14 @@ class ParserTest extends munit.ScalaCheckSuite {
 
   property("anyChar.repAs0[String] parses the whole string") {
     forAll { (str: String) =>
-      assertEquals(Parser0.anyChar.repAs0[String].parse(str), Right(("", str)))
+      assertEquals(Parser.anyChar.repAs0[String].parse(str), Right(("", str)))
     }
   }
 
   property("string.soft ~ string is the same as concatenating the string") {
     forAll { (str1: String, str2: String, content: String) =>
-      val left = (Parser0.string0(str1).soft ~ Parser0.string0(str2)).void
-      val right = Parser0.string0(str1 + str2)
+      val left = (Parser.string0(str1).soft ~ Parser.string0(str2)).void
+      val right = Parser.string0(str1 + str2)
 
       val leftRes = left.parse(content).toOption
       val rightRes = right.parse(content).toOption
@@ -1653,27 +1653,27 @@ class ParserTest extends munit.ScalaCheckSuite {
     }
   }
 
-  property("Parser0.string(f).string == Parser0.string(f).as(f)") {
+  property("Parser.string(f).string == Parser.string(f).as(f)") {
     forAll { (f: String) =>
       if (f.length > 1)
-        assertEquals(Parser0.string(f).string, Parser0.string(f).as(f))
+        assertEquals(Parser.string(f).string, Parser.string(f).as(f))
 
     }
   }
 
   property("char(c).as(c) == charIn(c)") {
     forAll { (c: Char) =>
-      assertEquals(Parser0.char(c).as(c.toString), Parser0.char(c).string)
-      assertEquals(Parser0.char(c).as(c), Parser0.charIn(c))
-      assertEquals(Parser0.char(c).void.as(c), Parser0.charIn(c))
-      assertEquals(Parser0.char(c).string.as(c), Parser0.charIn(c))
+      assertEquals(Parser.char(c).as(c.toString), Parser.char(c).string)
+      assertEquals(Parser.char(c).as(c), Parser.charIn(c))
+      assertEquals(Parser.char(c).void.as(c), Parser.charIn(c))
+      assertEquals(Parser.char(c).string.as(c), Parser.charIn(c))
     }
   }
 
   property("select(pa.map(Left(_)))(pf) == (pa, pf).mapN((a, fn) => fn(a))") {
     forAll { (pa: Parser0[Int], pf: Parser0[Int => String], str: String) =>
       assertEquals(
-        Parser0.select0(pa.map(Left(_)))(pf).parse(str),
+        Parser.select0(pa.map(Left(_)))(pf).parse(str),
         (pa, pf).mapN((a, f) => f(a)).parse(str)
       )
     }
@@ -1682,7 +1682,7 @@ class ParserTest extends munit.ScalaCheckSuite {
   property("select1(pa.map(Left(_)))(pf) == (pa, pf).mapN((a, fn) => fn(a))") {
     forAll { (pa: Parser[Int], pf: Parser0[Int => String], str: String) =>
       assertEquals(
-        Parser0.select(pa.map(Left(_)))(pf).parse(str),
+        Parser.select(pa.map(Left(_)))(pf).parse(str),
         (pa, pf).mapN((a, f) => f(a)).parse(str)
       )
     }
@@ -1690,13 +1690,13 @@ class ParserTest extends munit.ScalaCheckSuite {
 
   property("select(pa.map(Right(_)))(pf) == pa") {
     forAll { (pa: Parser0[String], pf: Parser0[Int => String], str: String) =>
-      assertEquals(Parser0.select0(pa.map(Right(_)))(pf).parse(str), pa.parse(str))
+      assertEquals(Parser.select0(pa.map(Right(_)))(pf).parse(str), pa.parse(str))
     }
   }
 
   property("select1(pa.map(Right(_)))(pf) == pa") {
     forAll { (pa: Parser[String], pf: Parser0[Int => String], str: String) =>
-      assertEquals(Parser0.select(pa.map(Right(_)))(pf).parse(str), pa.parse(str))
+      assertEquals(Parser.select(pa.map(Right(_)))(pf).parse(str), pa.parse(str))
     }
   }
 
@@ -1718,17 +1718,17 @@ class ParserTest extends munit.ScalaCheckSuite {
   property("select on pure values works as expected") {
     forAll { (left: Option[Either[Int, String]], right: Option[Int => String], str: String) =>
       val pleft = left match {
-        case Some(e) => Parser0.pure(e)
-        case None => Parser0.fail
+        case Some(e) => Parser.pure(e)
+        case None => Parser.fail
       }
 
       val pright = right match {
-        case Some(f) => Parser0.pure(f)
-        case None => Parser0.fail
+        case Some(f) => Parser.pure(f)
+        case None => Parser.fail
       }
 
       assertEquals(
-        Parser0.select0(pleft)(pright).parse(str).toOption.map(_._2),
+        Parser.select0(pleft)(pright).parse(str).toOption.map(_._2),
         left.flatMap {
           case Left(i) => right.map(_(i))
           case Right(s) =>

--- a/core/shared/src/test/scala/cats/parse/Rfc5234Test.scala
+++ b/core/shared/src/test/scala/cats/parse/Rfc5234Test.scala
@@ -28,7 +28,7 @@ import org.scalacheck.Prop.forAll
 class Rfc5234Test extends munit.ScalaCheckSuite {
   val allChars: Set[Char] = Set(Char.MinValue to Char.MaxValue: _*)
 
-  def singleCharProperties[A](name: String, rule: Parser[A], valid: Set[Char], f: Char => A) = {
+  def singleCharProperties[A](name: String, rule: Parser0[A], valid: Set[Char], f: Char => A) = {
     val genValid = Gen.oneOf(valid)
     // Bias toward the chars we tend to find in these parsers
     val genInvalid = Gen.frequency(
@@ -58,10 +58,10 @@ class Rfc5234Test extends munit.ScalaCheckSuite {
     }
   }
 
-  def singleConstCharProperties(name: String, rule: Parser[Unit], valid: Char) =
+  def singleConstCharProperties(name: String, rule: Parser0[Unit], valid: Char) =
     singleCharProperties(name, rule, Set(valid), _ => ())
 
-  def singleMultiCharProperties(name: String, rule: Parser[Char], valid: Set[Char]) =
+  def singleMultiCharProperties(name: String, rule: Parser0[Char], valid: Set[Char]) =
     singleCharProperties(name, rule, valid, identity)
 
   singleMultiCharProperties(

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -37,43 +37,43 @@ import cats.parse.bench.self.JsonStringUtil
 ```
 
 ```scala mdoc
-import cats.parse.{Parser0 => P, Parser, Numbers}
+import cats.parse.{Parser0 => P0, Parser, Numbers}
 import org.typelevel.jawn.ast._
 
 object Json {
-  private[this] val whitespace: Parser[Unit] = P.charIn(" \t\r\n").void
-  private[this] val whitespaces0: P[Unit] = whitespace.rep.void
+  private[this] val whitespace: Parser[Unit] = P0.charIn(" \t\r\n").void
+  private[this] val whitespaces0: P0[Unit] = whitespace.rep.void
 
   val parser: Parser[JValue] = {
-    val recurse = P.defer1(parser)
-    val pnull = P.string1("null").as(JNull)
-    val bool = P.string1("true").as(JBool.True).orElse1(P.string1("false").as(JBool.False))
+    val recurse = P0.defer1(parser)
+    val pnull = P0.string1("null").as(JNull)
+    val bool = P0.string1("true").as(JBool.True).orElse1(P0.string1("false").as(JBool.False))
     val justStr = JsonStringUtil.escapedString('"')
     val str = justStr.map(JString(_))
     val num = Numbers.jsonNumber.map(JNum(_))
 
     val listSep: Parser[Unit] =
-      P.char(',').surroundedBy(whitespaces0).void
+      P0.char(',').surroundedBy(whitespaces0).void
 
-    def rep[A](pa: Parser[A]): P[List[A]] =
-      P.repSep(pa, min = 0, sep = listSep).surroundedBy(whitespaces0)
+    def rep[A](pa: Parser[A]): P0[List[A]] =
+      P0.repSep(pa, min = 0, sep = listSep).surroundedBy(whitespaces0)
 
     val list = rep(recurse).with1
-      .between(P.char('['), P.char(']'))
+      .between(P0.char('['), P0.char(']'))
       .map { vs => JArray.fromSeq(vs) }
 
     val kv: Parser[(String, JValue)] =
-      justStr ~ (P.char(':').surroundedBy(whitespaces0) *> recurse)
+      justStr ~ (P0.char(':').surroundedBy(whitespaces0) *> recurse)
 
     val obj = rep(kv).with1
-      .between(P.char('{'), P.char('}'))
+      .between(P0.char('{'), P0.char('}'))
       .map { vs => JObject.fromSeq(vs) }
 
-    P.oneOf1(str :: num :: list :: obj :: bool :: pnull :: Nil)
+    P0.oneOf1(str :: num :: list :: obj :: bool :: pnull :: Nil)
   }
 
   // any whitespace followed by json followed by whitespace followed by end
-  val parserFile: Parser[JValue] = whitespaces0.with1 *> parser <* (whitespaces0 ~ P.end)
+  val parserFile: Parser[JValue] = whitespaces0.with1 *> parser <* (whitespaces0 ~ P0.end)
 }
 ```
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -37,7 +37,7 @@ import cats.parse.bench.self.JsonStringUtil
 ```
 
 ```scala mdoc
-import cats.parse.{Parser => P, Parser1, Numbers}
+import cats.parse.{Parser00 => P, Parser1, Numbers}
 import org.typelevel.jawn.ast._
 
 object Json {
@@ -121,7 +121,7 @@ is written, but these results suggest that this library is already quite competi
 You should find all the Fastparse methods you are used to. If not, feel free to open an issue.
 There are a few things to keep in mind:
 
-1. In fastparse, you wrap a parser in `P(...)` to make the interior lazy. Following cats, to get a lazily constructed parser use `Parser.defer` or `cats.Defer[Parser].defer`.
+1. In fastparse, you wrap a parser in `P(...)` to make the interior lazy. Following cats, to get a lazily constructed parser use `Parser0.defer` or `cats.Defer[Parser].defer`.
 2. In fastparse the `~` operator does tuple concatenation. This can be nice, but also complex to see what the resulting type is. In cats-parse, `~` always returns a Tuple2 containing the parsed values from the left and right. To recover fastparse-like behavior, use cats syntax `(pa, pb, pc...).tupled`.
 3. In fastparse, backtracking is opt-out by using cuts. In cats-parse, backtracking is opt-in using `.backtrack`. Put another way, normal product operations in cats-parse are like `~/` in fastparse.
 4. In cats-parse, using `*>`, `<*`, and `.void` methods can be a significant optimization: if you don't need a result, communicate that to the library with those methods.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -121,7 +121,7 @@ is written, but these results suggest that this library is already quite competi
 You should find all the Fastparse methods you are used to. If not, feel free to open an issue.
 There are a few things to keep in mind:
 
-1. In fastparse, you wrap a parser in `P(...)` to make the interior lazy. Following cats, to get a lazily constructed parser use `Parser0.defer` or `cats.Defer[Parser].defer`.
+1. In fastparse, you wrap a parser in `P(...)` to make the interior lazy. Following cats, to get a lazily constructed parser use `Parser.defer` or `cats.Defer[Parser].defer`.
 2. In fastparse the `~` operator does tuple concatenation. This can be nice, but also complex to see what the resulting type is. In cats-parse, `~` always returns a Tuple2 containing the parsed values from the left and right. To recover fastparse-like behavior, use cats syntax `(pa, pb, pc...).tupled`.
 3. In fastparse, backtracking is opt-out by using cuts. In cats-parse, backtracking is opt-in using `.backtrack`. Put another way, normal product operations in cats-parse are like `~/` in fastparse.
 4. In cats-parse, using `*>`, `<*`, and `.void` methods can be a significant optimization: if you don't need a result, communicate that to the library with those methods.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -56,7 +56,7 @@ object Json {
       P0.char(',').surroundedBy(whitespaces0).void
 
     def rep[A](pa: Parser[A]): P0[List[A]] =
-      P0.repSep(pa, min = 0, sep = listSep).surroundedBy(whitespaces0)
+      P0.rep0Sep(pa, min = 0, sep = listSep).surroundedBy(whitespaces0)
 
     val list = rep(recurse).with1
       .between(P0.char('['), P0.char(']'))

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -24,7 +24,7 @@ this library has a few goals:
 2. Excellent performance: should be as fast or faster than any parser combinator that has comparable scala version support.
 3. Cats friendliness: method names match cats style, and out of the box support for cats typeclasses.
 4. Precise errors: following the [Haskell Trifecta parsing library](https://hackage.haskell.org/package/trifecta), backtracking is opt-in vs opt-out. This design tends to make it easier to write parsers that point correctly to failure points.
-5. Safety: by separating Parser0 from Parser, a parser that may consume no input, we demand that Parser must consume at least one character on success. Most combinators and methods can be made safer to use and less prone to runtime errors.
+5. Safety: by separating Parser0, a parser that may consume no input, from Parser, a parser must consume at least one character on success. Most combinators and methods can be made safer to use and less prone to runtime errors.
 6. Stability: we are very reluctant to break compatibility between versions. We want to put a minimal tax on users to stay on the latest versions.
 
 # An Example
@@ -37,43 +37,43 @@ import cats.parse.bench.self.JsonStringUtil
 ```
 
 ```scala mdoc
-import cats.parse.{Parser0 => P0, Parser, Numbers}
+import cats.parse.{Parser0, Parser => P, Numbers}
 import org.typelevel.jawn.ast._
 
 object Json {
-  private[this] val whitespace: Parser[Unit] = P0.charIn(" \t\r\n").void
-  private[this] val whitespaces0: P0[Unit] = whitespace.rep.void
+  private[this] val whitespace: P[Unit] = P.charIn(" \t\r\n").void
+  private[this] val whitespaces0: P[Unit] = whitespace.rep.void
 
-  val parser: Parser[JValue] = {
-    val recurse = P0.defer1(parser)
-    val pnull = P0.string1("null").as(JNull)
-    val bool = P0.string1("true").as(JBool.True).orElse1(P0.string1("false").as(JBool.False))
+  val parser: P[JValue] = {
+    val recurse = P.defer(parser)
+    val pnull = P.string("null").as(JNull)
+    val bool = P.string("true").as(JBool.True).orElse(P.string("false").as(JBool.False))
     val justStr = JsonStringUtil.escapedString('"')
     val str = justStr.map(JString(_))
     val num = Numbers.jsonNumber.map(JNum(_))
 
-    val listSep: Parser[Unit] =
-      P0.char(',').surroundedBy(whitespaces0).void
+    val listSep: P[Unit] =
+      P.char(',').surroundedBy(whitespaces0).void
 
-    def rep[A](pa: Parser[A]): P0[List[A]] =
-      P0.rep0Sep(pa, min = 0, sep = listSep).surroundedBy(whitespaces0)
+    def rep[A](pa: P[A]): Parser0[List[A]] =
+      P.rep0Sep(pa, min = 0, sep = listSep).surroundedBy(whitespaces0)
 
     val list = rep(recurse).with1
-      .between(P0.char('['), P0.char(']'))
+      .between(P.char('['), P.char(']'))
       .map { vs => JArray.fromSeq(vs) }
 
-    val kv: Parser[(String, JValue)] =
-      justStr ~ (P0.char(':').surroundedBy(whitespaces0) *> recurse)
+    val kv: P[(String, JValue)] =
+      justStr ~ (P.char(':').surroundedBy(whitespaces0) *> recurse)
 
     val obj = rep(kv).with1
-      .between(P0.char('{'), P0.char('}'))
+      .between(P.char('{'), P.char('}'))
       .map { vs => JObject.fromSeq(vs) }
 
-    P0.oneOf1(str :: num :: list :: obj :: bool :: pnull :: Nil)
+    P.oneOf(str :: num :: list :: obj :: bool :: pnull :: Nil)
   }
 
   // any whitespace followed by json followed by whitespace followed by end
-  val parserFile: Parser[JValue] = whitespaces0.with1 *> parser <* (whitespaces0 ~ P0.end)
+  val parserFile: P[JValue] = whitespaces0.with1 *> parser <* (whitespaces0 ~ P.end)
 }
 ```
 


### PR DESCRIPTION
To illustrate https://github.com/typelevel/cats-parse/issues/113

Moved the constructors and their helper wrappers to `object Parser` (in the easiest way possible, by loosening access), in the second to last commit, and taking things to their logical extreme in I removed `parse` and `parseAll` from `Parser0`: it makes little sense to run an end-parser on a string that may not consume any characters, 

That the intuition works out is shown in that none of the "real world" tests needed changing other than catching that some `Parser(1)`'s could be `Parser0`'s.

Todo: Fixup the fallout of submitting too early while by while writing up the body of the PR and still running tests.
