### PR TITLE
Some minor nits post Parser0 change

### DIFF
--- a/bench/src/main/scala/cats/parse/bench/self.scala
+++ b/bench/src/main/scala/cats/parse/bench/self.scala
@@ -21,7 +21,6 @@
 
 package cats.parse.bench.self
 
-import cats.implicits._
 import cats.parse.{Parser0 => P0, Parser => P, Numbers}
 import org.typelevel.jawn.ast._
 

--- a/bench/src/main/scala/cats/parse/bench/self.scala
+++ b/bench/src/main/scala/cats/parse/bench/self.scala
@@ -132,7 +132,7 @@ abstract class GenericStringUtil {
   def escapedString(q: Char): P[String] = {
     val end: P[Unit] = P.char(q)
     end *> ((simpleString <* end).backtrack
-      .orElse0(undelimitedString(end) <* end))
+      .orElse(undelimitedString(end) <* end))
   }
 
   def escape(quoteChar: Char, str: String): String = {

--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -1462,7 +1462,10 @@ object Parser {
 
     }
 
-  private[parse] final class State(val str: String) {
+  /*
+   * This is protected rather than private to avoid a warning on 2.12
+   */
+  protected[parse] final class State(val str: String) {
     var offset: Int = 0
     var error: Chain[Expectation] = null
     var capture: Boolean = true

--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -66,7 +66,7 @@ sealed abstract class Parser0[+A] {
     * To require the entire input to be consumed, see `parseAll`.
     */
   final def parse(str: String): Either[Parser.Error, (String, A)] = {
-    val state = new Parser.Impl.State(str)
+    val state = new Parser.State(str)
     val result = parseMut(state)
     val err = state.error
     val offset = state.offset
@@ -83,7 +83,7 @@ sealed abstract class Parser0[+A] {
     * `p.parseAll(s)` is equivalent to `(p <* Parser.end).parse(s).map(_._2)`.
     */
   final def parseAll(str: String): Either[Parser.Error, A] = {
-    val state = new Parser.Impl.State(str)
+    val state = new Parser.State(str)
     val result = parseMut(state)
     val err = state.error
     val offset = state.offset
@@ -110,7 +110,7 @@ sealed abstract class Parser0[+A] {
     * will still fail.
     */
   def ? : Parser0[Option[A]] =
-    Parser.oneOf0(Parser.map0(this)(Some(_)) :: Parser.Impl.optTail)
+    Parser.oneOf0(Parser.map0(this)(Some(_)) :: Parser.optTail)
 
   /** If this parser fails to parse its input with an epsilon error,
     * try the given parser instead.
@@ -179,6 +179,22 @@ sealed abstract class Parser0[+A] {
   def ~[B](that: Parser0[B]): Parser0[(A, B)] =
     Parser.product0(this, that)
 
+  /** Compose two parsers, ignoring the values extracted by the
+    * left-hand parser.
+    *
+    * `x *> y` is equivalent to `(x.void ~ y).map(_._2)`.
+    */
+  def *>[B](that: Parser0[B]): Parser0[B] =
+    (void ~ that).map(_._2)
+
+  /** Compose two parsers, ignoring the values extracted by the
+    * right-hand parser.
+    *
+    * `x <* y` is equivalent to `(x ~ y.void).map(_._1)`.
+    */
+  def <*[B](that: Parser0[B]): Parser0[A] =
+    (this ~ that.void).map(_._1)
+
   /** If this parser fails to parse its input with an epsilon error,
     * try the given parser instead.
     *
@@ -189,7 +205,7 @@ sealed abstract class Parser0[+A] {
     * one to pick up after any error, resetting any state that was
     * modified by the left parser.
     */
-  def orElse0[A1 >: A](that: Parser0[A1]): Parser0[A1] =
+  def orElse[A1 >: A](that: Parser0[A1]): Parser0[A1] =
     Parser.oneOf0(this :: that :: Nil)
 
   /** Transform parsed values using the given function.
@@ -333,7 +349,7 @@ sealed abstract class Parser0[+A] {
     *
     * This method should only be called internally by parser instances.
     */
-  private[parse] def parseMut(state: Parser.Impl.State): A
+  private[parse] def parseMut(state: Parser.State): A
 }
 
 /** Parser[A] is a Parser0[A] that will always consume one-or-more
@@ -388,20 +404,14 @@ sealed abstract class Parser[+A] extends Parser0[A] {
   override def ~[B](that: Parser0[B]): Parser[(A, B)] =
     Parser.product10(this, that)
 
-  /** Compose two parsers, ignoring the values extracted by the
-    * left-hand parser.
-    *
-    * `x *> y` is equivalent to `(x.void ~ y).map(_._2)`.
+  /** This method overrides `Parser0#*>` to refine the return type.
     */
-  def *>[B](that: Parser0[B]): Parser[B] =
+  override def *>[B](that: Parser0[B]): Parser[B] =
     (void ~ that).map(_._2)
 
-  /** Compose two parsers, ignoring the values extracted by the
-    * right-hand parser.
-    *
-    * `x <* y` is equivalent to `(x ~ y.void).map(_._1)`.
+  /** This method overrides `Parser0#<*` to refine the return type.
     */
-  def <*[B](that: Parser0[B]): Parser[A] =
+  override def <*[B](that: Parser0[B]): Parser[A] =
     (this ~ that.void).map(_._1)
 
   /** This method overrides `Parser0#collect` to refine the return type.
@@ -475,7 +485,7 @@ sealed abstract class Parser[+A] extends Parser0[A] {
     */
   def rep0(min: Int): Parser0[List[A]] =
     if (min == 0) rep0
-    else rep(min).map(_.toList)
+    else this.repAs(min)
 
   /** Use this parser to parse one-or-more values.
     *
@@ -833,7 +843,7 @@ object Parser {
     *  as long as they are epsilon failures (don't advance)
     *  see @backtrack if you want to do backtracking.
     *
-    *  This is the same as parsers.foldLeft(fail)(_.orElse0(_))
+    *  This is the same as parsers.foldLeft(fail)(_.orElse(_))
     */
   def oneOf0[A](ps: List[Parser0[A]]): Parser0[A] = {
     @annotation.tailrec
@@ -890,6 +900,8 @@ object Parser {
 
   private[this] val emptyStringParser0: Parser0[String] =
     pure("")
+
+  private[parse] val optTail: List[Parser0[Option[Nothing]]] = Parser.pure(None) :: Nil
 
   /** if len < 1, the same as pure("")
     * else length(len)
@@ -999,22 +1011,30 @@ object Parser {
   def map0[A, B](p: Parser0[A])(fn: A => B): Parser0[B] =
     p match {
       case p1: Parser[A] => map(p1)(fn)
-      case Impl.Map(p0, f0) =>
-        Impl.Map(p0, AndThen(f0).andThen(fn))
-      case _ => Impl.Map(p, fn)
+      case Impl.Map0(p0, f0) =>
+        val f1 = f0 match {
+          case Impl.ConstFn(a) => Impl.ConstFn(fn(a))
+          case _ => AndThen(f0).andThen(fn)
+        }
+        Impl.Map0(p0, f1)
+      case _ => Impl.Map0(p, fn)
     }
 
   /** transform a Parser result
     */
   def map[A, B](p: Parser[A])(fn: A => B): Parser[B] =
     p match {
-      case Impl.Map1(p0, f0) =>
-        Impl.Map1(p0, AndThen(f0).andThen(fn))
+      case Impl.Map(p0, f0) =>
+        val f1 = f0 match {
+          case Impl.ConstFn(a) => Impl.ConstFn(fn(a))
+          case _ => AndThen(f0).andThen(fn)
+        }
+        Impl.Map(p0, f1)
       case Impl.Fail() | Impl.FailWith(_) =>
         // these are really Parser[Nothing{
         // but scala can't see that, so we cast
         p.asInstanceOf[Parser[B]]
-      case _ => Impl.Map1(p, fn)
+      case _ => Impl.Map(p, fn)
     }
 
   /** Parse p and if we get the Left side, parse fn
@@ -1086,7 +1106,7 @@ object Parser {
     *  parser is less amenable to optimization
     */
   def tailRecM[A, B](init: A)(fn: A => Parser[Either[A, B]]): Parser[B] =
-    Impl.TailRecM1(init, fn)
+    Impl.TailRecM(init, fn)
 
   /** Lazily create a Parser
     *  This is useful to create some recursive parsers
@@ -1442,11 +1462,15 @@ object Parser {
 
     }
 
-  private[parse] object Impl {
+  private[parse] final class State(val str: String) {
+    var offset: Int = 0
+    var error: Chain[Expectation] = null
+    var capture: Boolean = true
+  }
+
+  private object Impl {
 
     val allChars = Char.MinValue to Char.MaxValue
-
-    val optTail: List[Parser0[Option[Nothing]]] = Parser.pure(None) :: Nil
 
     case class ConstFn[A](result: A) extends Function[Any, A] {
       def apply(any: Any) = result
@@ -1461,8 +1485,8 @@ object Parser {
         case Backtrack0(_) | Backtrack(_) | AnyChar | CharIn(_, _, _) | Str(_) | IgnoreCase(_) |
             Length(_) | StartParser | EndParser | Index | Pure(_) | Fail() | FailWith(_) | Not(_) =>
           true
+        case Map0(p, _) => doesBacktrack(p)
         case Map(p, _) => doesBacktrack(p)
-        case Map1(p, _) => doesBacktrack(p)
         case SoftProd0(a, b) => doesBacktrackCheat(a) && doesBacktrack(b)
         case SoftProd(a, b) => doesBacktrackCheat(a) && doesBacktrack(b)
         case _ => false
@@ -1474,7 +1498,7 @@ object Parser {
     final def alwaysSucceeds(p: Parser0[Any]): Boolean =
       p match {
         case Index | Pure(_) => true
-        case Map(p, _) => alwaysSucceeds(p)
+        case Map0(p, _) => alwaysSucceeds(p)
         case SoftProd0(a, b) => alwaysSucceeds(a) && alwaysSucceeds(b)
         case Prod0(a, b) => alwaysSucceeds(a) && alwaysSucceeds(b)
         // by construction we never build a Not(Fail()) since
@@ -1494,7 +1518,7 @@ object Parser {
         case p1: Parser[Any] => unmap(p1)
         case Pure(_) | Index => Parser.unit
         case s if alwaysSucceeds(s) => Parser.unit
-        case Map(p, _) =>
+        case Map0(p, _) =>
           // we discard any allocations done by fn
           unmap0(p)
         case Select0(p, fn) =>
@@ -1571,7 +1595,7 @@ object Parser {
       */
     def unmap(pa: Parser[Any]): Parser[Any] =
       pa match {
-        case Map1(p, _) =>
+        case Map(p, _) =>
           // we discard any allocations done by fn
           unmap(p)
         case Select(p, fn) =>
@@ -1632,17 +1656,11 @@ object Parser {
           Defer(() => unmap(compute(fn)))
         case Rep(p, m, _) => Rep(unmap(p), m, Accumulator0.unitAccumulator0)
         case AnyChar | CharIn(_, _, _) | Str(_) | IgnoreCase(_) | Fail() | FailWith(_) | Length(_) |
-            TailRecM1(_, _) | FlatMap(_, _) =>
+            TailRecM(_, _) | FlatMap(_, _) =>
           // we can't transform this significantly
           pa
 
       }
-
-    final class State(val str: String) {
-      var offset: Int = 0
-      var error: Chain[Expectation] = null
-      var capture: Boolean = true
-    }
 
     case class Pure[A](result: A) extends Parser0[A] {
       override def parseMut(state: State): A = result
@@ -1884,11 +1902,11 @@ object Parser {
       else null.asInstanceOf[B]
     }
 
-    case class Map[A, B](parser: Parser0[A], fn: A => B) extends Parser0[B] {
+    case class Map0[A, B](parser: Parser0[A], fn: A => B) extends Parser0[B] {
       override def parseMut(state: State): B = Impl.map(parser, fn, state)
     }
 
-    case class Map1[A, B](parser: Parser[A], fn: A => B) extends Parser[B] {
+    case class Map[A, B](parser: Parser[A], fn: A => B) extends Parser[B] {
       override def parseMut(state: State): B = Impl.map(parser, fn, state)
     }
 
@@ -1980,7 +1998,7 @@ object Parser {
       override def parseMut(state: State): B = Impl.tailRecM(p1, fn, state)
     }
 
-    case class TailRecM1[A, B](init: A, fn: A => Parser[Either[A, B]]) extends Parser[B] {
+    case class TailRecM[A, B](init: A, fn: A => Parser[Either[A, B]]) extends Parser[B] {
       private[this] val p1 = fn(init)
 
       override def parseMut(state: State): B = Impl.tailRecM(p1, fn, state)

--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -1694,8 +1694,9 @@ object Parser {
         case Defer(fn) =>
           Defer(UnmapDefer(fn))
         case Rep(p, m, _) => Rep(unmap(p), m, Accumulator0.unitAccumulator0)
-        case AnyChar | CharIn(_, _, _) | Str(_) | StringIn(_) | IgnoreCase(_) | Fail() |
-          FailWith(_) | Length(_) | TailRecM(_, _) | FlatMap(_, _) =>
+        case AnyChar | CharIn(_, _, _) | Str(_) | StringIn(_) | IgnoreCase(_) | Fail() | FailWith(
+              _
+            ) | Length(_) | TailRecM(_, _) | FlatMap(_, _) =>
           // we can't transform this significantly
           pa
 

--- a/core/shared/src/test/scala/cats/parse/ParserTest.scala
+++ b/core/shared/src/test/scala/cats/parse/ParserTest.scala
@@ -1806,4 +1806,16 @@ class ParserTest extends munit.ScalaCheckSuite {
       assertEquals(left.parse(str), right.parse(str))
     }
   }
+
+  property("p.as(a).map(fn) == p.as(fn(a))") {
+    forAll(ParserGen.gen, Gen.choose(0, 128), Gen.function1[Int, Int](Gen.choose(0, 128))) {
+      (p, a, fn) =>
+        assertEquals(p.fa.as(a).map(fn), p.fa.as(fn(a)))
+    }
+
+    forAll(ParserGen.gen0, Gen.choose(0, 128), Gen.function1[Int, Int](Gen.choose(0, 128))) {
+      (p0, a, fn) =>
+        assertEquals(p0.fa.as(a).map(fn), p0.fa.as(fn(a)))
+    }
+  }
 }

--- a/core/shared/src/test/scala/cats/parse/ParserTest.scala
+++ b/core/shared/src/test/scala/cats/parse/ParserTest.scala
@@ -412,7 +412,7 @@ object ParserGen {
 
     Gen.zip(genFn1, genFn2).flatMap { case (f1, f2) =>
       Gen.oneOf(
-        GenT(ga.fa.map(f1).orElse0(gb.fa.map(f2))),
+        GenT(ga.fa.map(f1).orElse(gb.fa.map(f2))),
         GenT(MonoidK[Parser0].combineK(ga.fa.map(f1), gb.fa.map(f2)))
       )
     }
@@ -694,7 +694,7 @@ class ParserTest extends munit.ScalaCheckSuite {
     forAll(Gen.listOf(ParserGen.gen0), Gen.listOf(ParserGen.gen0), Arbitrary.arbitrary[String]) {
       (genP1, genP2, str) =>
         val oneOf = Parser.oneOf0((genP1 ::: genP2).map(_.fa))
-        val oneOf2 = Parser.oneOf0(genP1.map(_.fa)).orElse0(Parser.oneOf0(genP2.map(_.fa)))
+        val oneOf2 = Parser.oneOf0(genP1.map(_.fa)).orElse(Parser.oneOf0(genP2.map(_.fa)))
 
         assertEquals(oneOf.parse(str), oneOf2.parse(str))
     }
@@ -735,7 +735,7 @@ class ParserTest extends munit.ScalaCheckSuite {
 
   property("oneOf0 composes as expected") {
     forAll(ParserGen.gen0, ParserGen.gen0, Arbitrary.arbitrary[String]) { (genP1, genP2, str) =>
-      assertEquals(genP1.fa.orElse0(genP2.fa).parse(str), orElse(genP1.fa, genP2.fa, str))
+      assertEquals(genP1.fa.orElse(genP2.fa).parse(str), orElse(genP1.fa, genP2.fa, str))
     }
   }
 
@@ -745,10 +745,10 @@ class ParserTest extends munit.ScalaCheckSuite {
     }
   }
 
-  property("oneOf0 same as foldLeft(fail)(_.orElse0(_))") {
+  property("oneOf0 same as foldLeft(fail)(_.orElse(_))") {
     forAll(Gen.listOf(ParserGen.gen0), Arbitrary.arbitrary[String]) { (genP1, str) =>
       val oneOfImpl = genP1.foldLeft(Parser.fail: Parser0[Any]) { (leftp, p) =>
-        leftp.orElse0(p.fa)
+        leftp.orElse(p.fa)
       }
 
       assertEquals(oneOfImpl.parse(str), Parser.oneOf0(genP1.map(_.fa)).parse(str))
@@ -774,7 +774,7 @@ class ParserTest extends munit.ScalaCheckSuite {
 
   property("backtrack orElse pure always succeeds") {
     forAll(ParserGen.gen0, Arbitrary.arbitrary[String]) { (genP, str) =>
-      val p1 = genP.fa.backtrack.orElse0(Parser.pure(())): Parser0[Any]
+      val p1 = genP.fa.backtrack.orElse(Parser.pure(())): Parser0[Any]
 
       assert(p1.parse(str).isRight)
     }
@@ -1023,7 +1023,7 @@ class ParserTest extends munit.ScalaCheckSuite {
         Defer[Parser0].fix[List[A]] { tail =>
           (pa ~ tail)
             .map { case (h, t) => h :: t }
-            .orElse0(Parser.pure(Nil))
+            .orElse(Parser.pure(Nil))
         }
 
       val lst1 = rep0(genP.fa)
@@ -1041,7 +1041,7 @@ class ParserTest extends munit.ScalaCheckSuite {
         val repB = genP.fa
           .rep(min)
           .map(_.toList)
-          .orElse0(
+          .orElse(
             if (min == 0) Parser.pure(Nil)
             else Parser.fail
           )
@@ -1110,7 +1110,7 @@ class ParserTest extends munit.ScalaCheckSuite {
   property("p orElse p == p") {
     forAll(ParserGen.gen, Arbitrary.arbitrary[String]) { (genP, str) =>
       val res0 = genP.fa.parse(str)
-      val res1 = genP.fa.orElse0(genP.fa).parse(str)
+      val res1 = genP.fa.orElse(genP.fa).parse(str)
       assertEquals(res1, res0)
     }
   }
@@ -1133,9 +1133,9 @@ class ParserTest extends munit.ScalaCheckSuite {
     }
   }
 
-  property("p1.backtrack.orElse0(p2) succeeds if either p1 or p2 do") {
+  property("p1.backtrack.orElse(p2) succeeds if either p1 or p2 do (Parser0)") {
     forAll(ParserGen.gen0, ParserGen.gen0, Arbitrary.arbitrary[String]) { (p1, p2, str) =>
-      val ores = p1.fa.backtrack.orElse0(p2.fa).parse(str)
+      val ores = p1.fa.backtrack.orElse(p2.fa).parse(str)
       val r1 = p1.fa.parse(str)
       val r = if (r1.isLeft) p2.fa.parse(str) else r1
       (ores, r) match {
@@ -1366,15 +1366,15 @@ class ParserTest extends munit.ScalaCheckSuite {
    *
    * Instead, we have some weakened versions of distributive laws
    */
-  property("b.orElse0(c) ~ a == (b ~ a).orElse0((!b) *> (c ~ a))") {
+  property("b.orElse(c) ~ a == (b ~ a).orElse((!b) *> (c ~ a))") {
     forAll(ParserGen.gen0, ParserGen.gen0, ParserGen.gen0, Arbitrary.arbitrary[String]) {
       (a, b, c, str) =>
         val pa = a.fa
         val pb = b.fa
         val pc = c.fa
 
-        val left = pb.orElse0(pc) ~ pa
-        val right = (pb ~ pa).orElse0((!pb) *> (pc ~ pa))
+        val left = pb.orElse(pc) ~ pa
+        val right = (pb ~ pa).orElse((!pb) *> (pc ~ pa))
 
         val leftRes = left.parse(str).toOption
         val rightRes = right.parse(str).toOption
@@ -1400,15 +1400,15 @@ class ParserTest extends munit.ScalaCheckSuite {
     }
   }
 
-  property("a ~ b.orElse0(c) == (a.soft ~ b).orElse0(a ~ c)") {
+  property("a ~ b.orElse(c) == (a.soft ~ b).orElse(a ~ c)") {
     forAll(ParserGen.gen0, ParserGen.gen0, ParserGen.gen0, Arbitrary.arbitrary[String]) {
       (a, b, c, str) =>
         val pa = a.fa
         val pb = b.fa
         val pc = c.fa
 
-        val left = pa ~ pb.orElse0(pc)
-        val right = (pa.soft ~ pb).orElse0(pa ~ pc)
+        val left = pa ~ pb.orElse(pc)
+        val right = (pa.soft ~ pb).orElse(pa ~ pc)
 
         val leftRes = left.parse(str).toOption
         val rightRes = right.parse(str).toOption
@@ -1424,7 +1424,7 @@ class ParserTest extends munit.ScalaCheckSuite {
         val pc = c.fa
 
         val left = pa ~ pb.orElse(pc)
-        val right = (pa.soft.with1 ~ pb).orElse0(pa.with1 ~ pc)
+        val right = (pa.soft.with1 ~ pb).orElse(pa.with1 ~ pc)
 
         val leftRes = left.parse(str).toOption
         val rightRes = right.parse(str).toOption
@@ -1432,13 +1432,13 @@ class ParserTest extends munit.ScalaCheckSuite {
     }
   }
 
-  property("a.backtrack.orElse0(b) parses iff b.backtrack.orElse0(a)") {
+  property("a.backtrack.orElse(b) parses iff b.backtrack.orElse(a) (Parser0)") {
     forAll(ParserGen.gen0, ParserGen.gen0, Arbitrary.arbitrary[String]) { (a, b, str) =>
       val pa = a.fa
       val pb = b.fa
 
-      val left = pa.backtrack.orElse0(pb)
-      val right = pb.backtrack.orElse0(pa)
+      val left = pa.backtrack.orElse(pb)
+      val right = pb.backtrack.orElse(pa)
 
       val leftRes = left.parse(str)
       val rightRes = right.parse(str)
@@ -1540,13 +1540,13 @@ class ParserTest extends munit.ScalaCheckSuite {
     }
   }
 
-  property("a.backtrack.peek.orElse0(b.peek) == (a.backtrack.orElse0(b)).peek") {
+  property("a.backtrack.peek.orElse(b.peek) == (a.backtrack.orElse(b)).peek") {
     forAll(ParserGen.gen0, ParserGen.gen0, Arbitrary.arbitrary[String]) { (a, b, str) =>
       val pa = a.fa.backtrack
       val pb = b.fa
 
-      val left = pa.peek.orElse0(pb.peek)
-      val right = pa.orElse0(pb).peek
+      val left = pa.peek.orElse(pb.peek)
+      val right = pa.orElse(pb).peek
 
       val leftRes = left.parse(str).toOption
       val rightRes = right.parse(str).toOption


### PR DESCRIPTION
This is a minor change after #116

1. as discussed, with make orElse name the same. I was reluctant since I was nervous that scala wouldn't find the right method, but I guess it works fine.
2. a few name changes (Map1 becomes Map).
3. a couple minor optimizations (repAs in rep(min: Int), optimize `.as(foo).map(fn)` to be `.as(foo(fn))` to avoid evaluating fn on each value.
4. Make Impl private again, lift State out and make just that `private[parse]`. I prefer to use the stronger encapsulation (private) if we can.

What do you think @martijnhoekstra @regadas 