### PR TITLE
Some more pre-0.3.0 changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ project/plugins/project/
 # emacs
 TAGS
 
+# vim
+*.swp
+
 # vscode wants to put metals directories here
 .metals
 .bloop

--- a/bench/src/main/scala/cats/parse/bench/self.scala
+++ b/bench/src/main/scala/cats/parse/bench/self.scala
@@ -45,7 +45,7 @@ object Json {
       P.char(',').surroundedBy(whitespaces0).void
 
     def rep0[A](pa: P[A]): P0[List[A]] =
-      P.rep0Sep(pa, min = 0, sep = listSep).surroundedBy(whitespaces0)
+      P.repSep0(pa, min = 0, sep = listSep).surroundedBy(whitespaces0)
 
     val list = rep0(recurse).with1
       .between(P.char('['), P.char(']'))

--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -1071,6 +1071,8 @@ object Parser {
   /** Repeat 1 or more times with a separator
     */
   def repSep[A](p1: Parser[A], min: Int, sep: Parser0[Any]): Parser[NonEmptyList[A]] = {
+    // we validate here so the message matches what the user passes
+    // instead of transforming to min - 1 below
     if (min <= 0) throw new IllegalArgumentException(s"require min > 0, found: $min")
 
     val rest = (sep.void.with1.soft *> p1).rep0(min - 1)
@@ -1080,6 +1082,8 @@ object Parser {
   /** Repeat 1 or more times with a separator
     */
   def repSep[A](p1: Parser[A], min: Int, max: Int, sep: Parser0[Any]): Parser[NonEmptyList[A]] = {
+    // we validate here so the message matches what the user passes
+    // instead of transforming to min - 1 below
     if (min <= 0) throw new IllegalArgumentException(s"require min > 0, found: $min")
     if (max < min) throw new IllegalArgumentException(s"require max >= min, found: $max < $min")
 
@@ -1089,21 +1093,16 @@ object Parser {
 
   /** Repeat 0 or more times with a separator
     */
-  def repSep0[A](p1: Parser[A], min: Int, sep: Parser0[Any]): Parser0[List[A]] = {
-    if (min < 0) throw new IllegalArgumentException(s"require min >= 0, found: $min")
-
+  def repSep0[A](p1: Parser[A], min: Int, sep: Parser0[Any]): Parser0[List[A]] =
     if (min == 0) repSep(p1, 1, sep).?.map {
       case None => Nil
       case Some(nel) => nel.toList
     }
     else repSep(p1, min, sep).map(_.toList)
-  }
 
   /** Repeat 0 or more times with a separator
     */
-  def repSep0[A](p1: Parser[A], min: Int, max: Int, sep: Parser0[Any]): Parser0[List[A]] = {
-    if (min < 0) throw new IllegalArgumentException(s"require min >= 0, found: $min")
-
+  def repSep0[A](p1: Parser[A], min: Int, max: Int, sep: Parser0[Any]): Parser0[List[A]] =
     if (min == 0) {
       if (max == 0) pure(Nil)
       else
@@ -1112,7 +1111,6 @@ object Parser {
           case Some(nel) => nel.toList
         }
     } else repSep(p1, min, max, sep).map(_.toList)
-  }
 
   /** parse first then second
     */

--- a/core/shared/src/test/scala/cats/parse/ParserTest.scala
+++ b/core/shared/src/test/scala/cats/parse/ParserTest.scala
@@ -1229,11 +1229,11 @@ class ParserTest extends munit.ScalaCheckSuite {
     }
   }
 
-  property("rep0Sep with unit sep is the same as rep0") {
+  property("repSep0 with unit sep is the same as rep0") {
     forAll(ParserGen.gen, Gen.choose(0, Int.MaxValue), Arbitrary.arbitrary[String]) {
       (genP, min0, str) =>
         val min = min0 & Int.MaxValue
-        val p1a = Parser.rep0Sep(genP.fa, min = min, sep = Parser.unit)
+        val p1a = Parser.repSep0(genP.fa, min = min, sep = Parser.unit)
         val p1b = genP.fa.rep0(min = min)
 
         assertEquals(p1a.parse(str), p1b.parse(str))
@@ -1243,6 +1243,25 @@ class ParserTest extends munit.ScalaCheckSuite {
         val p2b = genP.fa.rep(min = min1)
 
         assertEquals(p2a.parse(str), p2b.parse(str))
+    }
+
+    val minMax =
+      for {
+        min <- Gen.choose(0, Int.MaxValue)
+        max <- Gen.choose(min, Int.MaxValue)
+      } yield (min, max)
+
+    forAll(ParserGen.gen, minMax, Arbitrary.arbitrary[String]) { case (genP, (min, max), str) =>
+      val p1a = Parser.repSep0(genP.fa, min = min, max = max, sep = Parser.unit)
+      val p1b = genP.fa.rep0(min = min, max = max)
+
+      assertEquals(p1a.parse(str), p1b.parse(str))
+
+      val min1 = if (min < 1) 1 else min
+      val p2a = Parser.repSep(genP.fa, min = min1, max = max, sep = Parser.unit)
+      val p2b = genP.fa.rep(min = min1, max = max)
+
+      assertEquals(p2a.parse(str), p2b.parse(str))
     }
   }
 

--- a/core/shared/src/test/scala/cats/parse/ParserTest.scala
+++ b/core/shared/src/test/scala/cats/parse/ParserTest.scala
@@ -182,7 +182,7 @@ object ParserGen {
     require(min >= 0, s"biasSmall($min) is invalid")
 
     val max0 = Int.MaxValue - min
-    val pow = 31 - Integer.numberOfLeadingZeros(max0)
+    val pow = 32 - Integer.numberOfLeadingZeros(max0)
     Gen
       .choose(0, pow)
       .flatMap { shifts =>

--- a/core/shared/src/test/scala/cats/parse/ParserTest.scala
+++ b/core/shared/src/test/scala/cats/parse/ParserTest.scala
@@ -177,10 +177,24 @@ object ParserGen {
     GenT[Parser0, List[g.A]](g.fa.rep0(min = min, max = max))
   }
 
+  // this makes an integer >= min, but with power law bias to smaller values
+  def biasSmall(min: Int): Gen[Int] = {
+    require(min >= 0, s"biasSmall($min) is invalid")
+
+    val max0 = Int.MaxValue - min
+    val pow = 31 - Integer.numberOfLeadingZeros(max0)
+    Gen
+      .choose(0, pow)
+      .flatMap { shifts =>
+        Gen.choose(0, max0 >> shifts)
+      }
+      .map(_ + min)
+  }
+
   def genRep0(g: GenT[Parser]): Gen[GenT[Parser0]] =
     for {
-      min <- Gen.choose(0, Int.MaxValue)
-      max <- Gen.choose(min, Int.MaxValue)
+      min <- biasSmall(0)
+      max <- biasSmall(min)
     } yield rep0(min, max, g)
 
   def rep(g: GenT[Parser]): GenT[Parser] = {
@@ -195,8 +209,8 @@ object ParserGen {
 
   def genRep(g: GenT[Parser]): Gen[GenT[Parser]] =
     for {
-      min <- Gen.choose(1, Int.MaxValue)
-      max <- Gen.choose(min, Int.MaxValue)
+      min <- biasSmall(1)
+      max <- biasSmall(min)
     } yield rep(min, max, g)
 
   def product0(ga: GenT[Parser0], gb: GenT[Parser0]): Gen[GenT[Parser0]] = {
@@ -567,7 +581,7 @@ object ParserGen {
 
 class ParserTest extends munit.ScalaCheckSuite {
 
-  import ParserGen.{arbParser0, arbParser}
+  import ParserGen.{arbParser0, arbParser, biasSmall}
 
   val tests: Int = if (BitSetUtil.isScalaJs) 50 else 2000
 
@@ -640,6 +654,18 @@ class ParserTest extends munit.ScalaCheckSuite {
     parseTest(Parser.stringIn(alternatives).string, "foobat", "foobat")
     parseTest(Parser.stringIn(List("foo", "foobar", "foofoo", "foobat")).string, "foot", "foo")
     parseTest(Parser.stringIn(List("foo", "foobar", "foofoo", "foobat")).string, "foobal", "foo")
+  }
+
+  property("biasSmall works") {
+    val genPair =
+      for {
+        min <- Gen.choose(0, Int.MaxValue)
+        small <- biasSmall(min)
+      } yield (min, small)
+
+    forAll(genPair) { case (min, s) =>
+      assert(s >= min)
+    }
   }
 
   property("Parser0 on success replaces parsed value") {
@@ -1093,19 +1119,13 @@ class ParserTest extends munit.ScalaCheckSuite {
   }
 
   property("rep0 is consistent with rep") {
-    forAll(ParserGen.gen, Gen.choose(0, Int.MaxValue), Arbitrary.arbitrary[String]) {
-      (genP, min0, str) =>
-        val min = min0 & Int.MaxValue
-        val repA = genP.fa.rep0(min)
-        val repB = genP.fa
-          .rep(min)
-          .map(_.toList)
-          .orElse(
-            if (min == 0) Parser.pure(Nil)
-            else Parser.fail
-          )
+    forAll(ParserGen.gen, biasSmall(1), Arbitrary.arbitrary[String]) { (genP, min, str) =>
+      val repA = genP.fa.rep0(min)
+      val repB = genP.fa
+        .rep(min)
+        .map(_.toList)
 
-        assertEquals(repA.parse(str), repB.parse(str))
+      assertEquals(repA.parse(str), repB.parse(str))
     }
   }
 
@@ -1136,9 +1156,10 @@ class ParserTest extends munit.ScalaCheckSuite {
 
   property("rep0 parses n entries, min <= n <= max") {
     val validMinMax = for {
-      min <- Gen.choose(0, Int.MaxValue)
-      max <- Gen.choose(min, Int.MaxValue)
+      min <- biasSmall(0)
+      max <- biasSmall(min)
     } yield (min, max)
+
     forAll(ParserGen.gen, validMinMax, Arbitrary.arbitrary[String]) { (genP, minmax, str) =>
       {
         val (min, max) = minmax
@@ -1151,9 +1172,8 @@ class ParserTest extends munit.ScalaCheckSuite {
   }
 
   property("rep0 parses at most max entries (min == 0)") {
-    forAll(ParserGen.gen, Gen.choose(0, Int.MaxValue), Arbitrary.arbitrary[String]) {
-      (genP, max, str) =>
-        genP.fa.rep0(0, max).parse(str).foreach { case (_, l) => assert(l.length <= max) }
+    forAll(ParserGen.gen, biasSmall(0), Arbitrary.arbitrary[String]) { (genP, max, str) =>
+      genP.fa.rep0(0, max).parse(str).foreach { case (_, l) => assert(l.length <= max) }
     }
   }
 
@@ -1230,27 +1250,25 @@ class ParserTest extends munit.ScalaCheckSuite {
   }
 
   property("repSep0 with unit sep is the same as rep0") {
-    forAll(ParserGen.gen, Gen.choose(0, Int.MaxValue), Arbitrary.arbitrary[String]) {
-      (genP, min0, str) =>
-        val min = min0 & Int.MaxValue
-        val p1a = Parser.repSep0(genP.fa, min = min, sep = Parser.unit)
-        val p1b = genP.fa.rep0(min = min)
-
-        assertEquals(p1a.parse(str), p1b.parse(str))
-
-        val min1 = if (min < 1) 1 else min
-        val p2a = Parser.repSep(genP.fa, min = min1, sep = Parser.unit)
-        val p2b = genP.fa.rep(min = min1)
-
-        assertEquals(p2a.parse(str), p2b.parse(str))
-    }
 
     val minMax =
       for {
-        min <- Gen.choose(0, Int.MaxValue)
-        max <- Gen.choose(min, Int.MaxValue)
+        min <- biasSmall(0)
+        max <- biasSmall(Integer.max(min, 1))
       } yield (min, max)
 
+    forAll(ParserGen.gen, biasSmall(0), Arbitrary.arbitrary[String]) { (genP, min, str) =>
+      val p1a = Parser.repSep0(genP.fa, min = min, sep = Parser.unit)
+      val p1b = genP.fa.rep0(min = min)
+
+      assertEquals(p1a.parse(str), p1b.parse(str))
+
+      val min1 = if (min < 1) 1 else min
+      val p2a = Parser.repSep(genP.fa, min = min1, sep = Parser.unit)
+      val p2b = genP.fa.rep(min = min1)
+
+      assertEquals(p2a.parse(str), p2b.parse(str))
+    } &&
     forAll(ParserGen.gen, minMax, Arbitrary.arbitrary[String]) { case (genP, (min, max), str) =>
       val p1a = Parser.repSep0(genP.fa, min = min, max = max, sep = Parser.unit)
       val p1b = genP.fa.rep0(min = min, max = max)
@@ -1360,17 +1378,17 @@ class ParserTest extends munit.ScalaCheckSuite {
       val pa: Parser[Any] = p1.fa
       val pb: Parser[Any] = p2.fa
       assertEquals(pa.orElse(pb), pa | pb)
-    }
+    } &&
     forAll(ParserGen.gen0, ParserGen.gen0) { (p1, p2) =>
       val pa: Parser0[Any] = p1.fa
       val pb: Parser0[Any] = p2.fa
       assertEquals(pa.orElse(pb), pa | pb)
-    }
+    } &&
     forAll(ParserGen.gen, ParserGen.gen0) { (p1, p2) =>
       val pa: Parser[Any] = p1.fa
       val pb: Parser0[Any] = p2.fa
       assertEquals(pa.orElse(pb), pa | pb)
-    }
+    } &&
     forAll(ParserGen.gen0, ParserGen.gen) { (p1, p2) =>
       val pa: Parser0[Any] = p1.fa
       val pb: Parser[Any] = p2.fa

--- a/core/shared/src/test/scala/cats/parse/RepParserConstructionTest.scala
+++ b/core/shared/src/test/scala/cats/parse/RepParserConstructionTest.scala
@@ -25,18 +25,25 @@ import org.scalacheck.Gen
 import org.scalacheck.Prop.forAll
 
 class RepParserConstructionTest extends munit.ScalaCheckSuite {
+  import ParserGen.biasSmall
 
-  val validMin = Gen.choose(1, Int.MaxValue)
-  val validMin0 = Gen.choose(0, Int.MaxValue)
-  val validMax = Gen.choose(1, Int.MaxValue)
+  override def scalaCheckTestParameters =
+    super.scalaCheckTestParameters
+      .withMinSuccessfulTests(1000)
+      .withMaxDiscardRatio(10)
+
+  val validMin = biasSmall(1)
+  val validMin0 = biasSmall(0)
+  val validMax = validMin
 
   val validMinMax = for {
     min <- validMin
-    max <- Gen.choose(min, Int.MaxValue)
+    max <- biasSmall(min)
   } yield (min, max)
+
   val validMinMax0 = for {
     min <- validMin0
-    max <- Gen.choose(math.max(min, 1), Int.MaxValue)
+    max <- biasSmall(min)
   } yield (min, max)
 
   val invalidMin = Gen.choose(Int.MinValue, 0)
@@ -44,15 +51,15 @@ class RepParserConstructionTest extends munit.ScalaCheckSuite {
   val invalidMax = Gen.choose(Int.MinValue, 0)
 
   val invalidMinMax = Gen.oneOf(
-    for (min <- validMin; max <- Gen.choose(1, min)) yield (min, max),
-    for (min <- invalidMin; max <- Gen.choose(min, Int.MaxValue)) yield (min, max),
+    for (min <- validMin; maxDiff <- biasSmall(1)) yield (min, min - maxDiff),
+    for (min <- invalidMin; max <- biasSmall(0)) yield (min, max),
     for (min <- invalidMin; max <- invalidMax) yield (min, max),
     for (min <- validMin; max <- invalidMax) yield (min, max)
   )
 
   val invalidMinMax0 = Gen.oneOf(
-    for (min <- validMin0; max <- Gen.choose(1, min)) yield (min, max),
-    for (min <- invalidMin0; max <- Gen.choose(min, Int.MaxValue)) yield (min, max),
+    for (min <- validMin0; maxDiff <- biasSmall(1)) yield (min, min - maxDiff),
+    for (min <- invalidMin0; max <- biasSmall(0)) yield (min, max),
     for (min <- invalidMin0; max <- invalidMax) yield (min, max),
     for (min <- validMin0; max <- invalidMax) yield (min, max)
   )

--- a/core/shared/src/test/scala/cats/parse/RepParserConstructionTest.scala
+++ b/core/shared/src/test/scala/cats/parse/RepParserConstructionTest.scala
@@ -72,6 +72,9 @@ class RepParserConstructionTest extends munit.ScalaCheckSuite {
         intercept[IllegalArgumentException] {
           Parser.anyChar.rep(min = min, max = max)
         }
+        intercept[IllegalArgumentException] {
+          Parser.repSep(Parser.anyChar, min = min, max = max, Parser.pure(""))
+        }
         assert(true)
       }
     }
@@ -111,6 +114,9 @@ class RepParserConstructionTest extends munit.ScalaCheckSuite {
       case (min: Int, max: Int) => {
         intercept[IllegalArgumentException] {
           Parser.anyChar.rep0(min = min, max = max)
+        }
+        intercept[IllegalArgumentException] {
+          Parser.repSep0(Parser.anyChar, min = min, max = max, Parser.pure(""))
         }
         assert(true)
       }

--- a/core/shared/src/test/scala/cats/parse/RepParserConstructionTest.scala
+++ b/core/shared/src/test/scala/cats/parse/RepParserConstructionTest.scala
@@ -51,14 +51,16 @@ class RepParserConstructionTest extends munit.ScalaCheckSuite {
   val invalidMax = Gen.choose(Int.MinValue, 0)
 
   val invalidMinMax = Gen.oneOf(
-    for (min <- validMin; maxDiff <- biasSmall(1)) yield (min, min - maxDiff),
+    for (min <- validMin; maxDiff <- biasSmall(1))
+      yield (min, Integer.min(min - maxDiff, Int.MinValue)),
     for (min <- invalidMin; max <- biasSmall(0)) yield (min, max),
     for (min <- invalidMin; max <- invalidMax) yield (min, max),
     for (min <- validMin; max <- invalidMax) yield (min, max)
   )
 
   val invalidMinMax0 = Gen.oneOf(
-    for (min <- validMin0; maxDiff <- biasSmall(1)) yield (min, min - maxDiff),
+    for (min <- validMin0; maxDiff <- biasSmall(1))
+      yield (min, Integer.min(min - maxDiff, Int.MinValue)),
     for (min <- invalidMin0; max <- biasSmall(0)) yield (min, max),
     for (min <- invalidMin0; max <- invalidMax) yield (min, max),
     for (min <- validMin0; max <- invalidMax) yield (min, max)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -56,7 +56,7 @@ object Json {
       P.char(',').surroundedBy(whitespaces0).void
 
     def rep[A](pa: P[A]): Parser0[List[A]] =
-      P.rep0Sep(pa, min = 0, sep = listSep).surroundedBy(whitespaces0)
+      P.repSep0(pa, min = 0, sep = listSep).surroundedBy(whitespaces0)
 
     val list = rep(recurse).with1
       .between(P.char('['), P.char(']'))


### PR DESCRIPTION
relates to #137 

This does a few things to make the API more consistent:

1. rename rep0Sep to repSep0. All the other methods with 0, such as repAs0, end in 0, this was the only one in the middle.
2. add a repSep variant with a maximum.
3. a few internal nits (use repExactly if possible, if repExactly is times = 1, just use map).


cc @regadas @martijnhoekstra 
