### PR TITLE
RepSep overload with no `min` parameter

### DIFF
--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -1077,7 +1077,7 @@ object Parser {
 
   /** Repeat `min` or more times with a separator, at least once.
     *
-    * @throws IllegalArgumentException if `min <= 0`
+    * @throws java.lang.IllegalArgumentException if `min <= 0`
     */
   def repSep[A](p1: Parser[A], min: Int, sep: Parser0[Any]): Parser[NonEmptyList[A]] = {
     // we validate here so the message matches what the user passes
@@ -1090,7 +1090,7 @@ object Parser {
 
   /** Repeat `min` or more, up to `max` times with a separator, at least once.
     *
-    * @throws IllegalArgumentException if `min <= 0` or `max < min`
+    * @throws java.lang.IllegalArgumentException if `min <= 0` or `max < min`
     */
   def repSep[A](p1: Parser[A], min: Int, max: Int, sep: Parser0[Any]): Parser[NonEmptyList[A]] = {
     // we validate here so the message matches what the user passes

--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -1109,7 +1109,7 @@ object Parser {
   /** Repeat 0 or more times with a separator
     */
   def repSep0[A](p1: Parser[A], min: Int, sep: Parser0[Any]): Parser0[List[A]] =
-    if (min == 0) repSep(p1, 1, sep).?.map {
+    if (min == 0) repSep(p1, sep).?.map {
       case None => Nil
       case Some(nel) => nel.toList
     }

--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -1072,6 +1072,13 @@ object Parser {
 
   /** Repeat 1 or more times with a separator
     */
+  def repSep[A](p1: Parser[A], sep: Parser0[Any]): Parser[NonEmptyList[A]] =
+    repSep(p1, min = 1, sep)
+
+  /** Repeat `min` or more times with a separator, at least once.
+    *
+    * @throws IllegalArgumentException if `min <= 0`
+    */
   def repSep[A](p1: Parser[A], min: Int, sep: Parser0[Any]): Parser[NonEmptyList[A]] = {
     // we validate here so the message matches what the user passes
     // instead of transforming to min - 1 below
@@ -1081,7 +1088,9 @@ object Parser {
     (p1 ~ rest).map { case (h, t) => NonEmptyList(h, t) }
   }
 
-  /** Repeat 1 or more times with a separator
+  /** Repeat `min` or more, up to `max` times with a separator, at least once.
+    *
+    * @throws IllegalArgumentException if `min <= 0` or `max < min`
     */
   def repSep[A](p1: Parser[A], min: Int, max: Int, sep: Parser0[Any]): Parser[NonEmptyList[A]] = {
     // we validate here so the message matches what the user passes

--- a/core/shared/src/main/scala/cats/parse/SemVer.scala
+++ b/core/shared/src/main/scala/cats/parse/SemVer.scala
@@ -52,12 +52,12 @@ object SemVer {
 
   val preReleaseIdentifier: Parser[String] = alphanumericIdentifier
 
-  val dotSeparatedBuildIdentifiers: Parser[String] = Parser.repSep(buildIdentifier, 1, dot).string
+  val dotSeparatedBuildIdentifiers: Parser[String] = Parser.repSep(buildIdentifier, dot).string
 
   val build: Parser[String] = dotSeparatedBuildIdentifiers
 
   val dotSeparatedPreReleaseIdentifiers: Parser[String] =
-    Parser.repSep(preReleaseIdentifier, 1, dot).string
+    Parser.repSep(preReleaseIdentifier, dot).string
 
   val preRelease: Parser[String] = dotSeparatedPreReleaseIdentifiers
 

--- a/core/shared/src/test/scala/cats/parse/ParserTest.scala
+++ b/core/shared/src/test/scala/cats/parse/ParserTest.scala
@@ -1297,7 +1297,7 @@ class ParserTest extends munit.ScalaCheckSuite {
     forAll(ParserGen.gen, Arbitrary.arbitrary[String]) { (genP, str) =>
       assertEquals(
         genP.fa.parse(str),
-        Parser.repSep(genP.fa, 1, Parser.fail).parse(str).map { case (rest, nel) =>
+        Parser.repSep(genP.fa, Parser.fail).parse(str).map { case (rest, nel) =>
           (rest, nel.head)
         }
       )

--- a/core/shared/src/test/scala/cats/parse/ParserTest.scala
+++ b/core/shared/src/test/scala/cats/parse/ParserTest.scala
@@ -1283,6 +1283,16 @@ class ParserTest extends munit.ScalaCheckSuite {
     }
   }
 
+  property("repSep without min is the same as repSep with min = 1") {
+    forAll(ParserGen.gen, ParserGen.gen, Arbitrary.arbitrary[String]) { (genP, genPSep, str) =>
+      {
+        val p = genP.fa
+        val psep = genPSep.fa
+        assertEquals(Parser.repSep(p, min = 1, psep).parse(str), Parser.repSep(p, psep).parse(str))
+      }
+    }
+  }
+
   property("repSep with sep = fail is the same as parsing 1") {
     forAll(ParserGen.gen, Arbitrary.arbitrary[String]) { (genP, str) =>
       assertEquals(


### PR DESCRIPTION
Closes #111 

The minimal implementation: does not include other possible extensions of repSep like repSepAs with accumulator or repSep with trailing separator.

