### PR TITLE
remove nonNegativeDigit in SemVer

### DIFF
--- a/core/shared/src/main/scala/cats/parse/SemVer.scala
+++ b/core/shared/src/main/scala/cats/parse/SemVer.scala
@@ -36,8 +36,6 @@ object SemVer {
 
   val letter: Parser[Char] = Parser.ignoreCaseCharIn('a' to 'z')
 
-  def positiveDigit: Parser[Char] = Numbers.nonZeroDigit
-
   val nonDigit: Parser[Char] = letter | hyphen
 
   val identifierChar: Parser[Char] = Numbers.digit | nonDigit


### PR DESCRIPTION
It's unused and there is no reason why you should use SemVer.positiveDigit over Numbers.nonZeroDigit

Could perhaps still go along with 0.3.0 in the hopes nobody uses it, and never will? Or deprecate first?


