### PR TITLE
Remove ParserMethods which is unneeded

### DIFF
--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -501,7 +501,7 @@ sealed abstract class Parser[+A] extends Parser0[A] {
   /** Repeat the parser `min` or more times, but no more than `max`
     *
     * The parser fails if it can't match at least `min` times
-    * After repeating the parser `max` times, the parser completes succesfully
+    * After repeating the parser `max` times, the parser completes successfully
     *
     * @throws java.lang.IllegalArgumentException if min < 0 or max < min
     */

--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -573,7 +573,7 @@ sealed abstract class Parser[+A] extends Parser0[A] {
   /** Repeat the parser `min` or more times, but no more than `max`
     *
     * The parser fails if it can't match at least `min` times
-    * After repeating the parser `max` times, the parser completes succesfully
+    * After repeating the parser `max` times, the parser completes successfully
     *
     * @throws java.lang.IllegalArgumentException if min < 1 or max < min
     */

--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -528,7 +528,7 @@ sealed abstract class Parser[+A] extends Parser0[A] {
   /** Repeat the parser `min` or more times, but no more than `max`
     *
     * The parser fails if it can't match at least `min` times
-    * After repeating the parser `max` times, the parser completes succesfully
+    * After repeating the parser `max` times, the parser completes successfully
     *
     * @throws java.lang.IllegalArgumentException if min < 1 or max < min
     */


### PR DESCRIPTION
Originally the `ParserMethods` class was intended to avoid writing a type like:

```scala
def repAs[A1 >: A, B](implicit acc: Accumulator[A1, B]): Parser[B]
```

But that is not needed because `Accumulator` and `Accumulator0` are contra variant in the first type parameter. Thus, we can put them as regular methods on `Parser[A]` without any ugly signatures and still be able to write `p.repAs[NonEmptyVector[Int]]` without having to name the input type (`Int` in this example).

This should be source compatible since we just moved implicit enrichments directly onto the class.

cc @martijnhoekstra @regadas 
