### PR TITLE
Update versions in README

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,13 +8,13 @@ To use in sbt add, the following to your `libraryDependencies`:
 
 ```scala
 // use this snippet for the JVM
-libraryDependencies += "org.typelevel" %% "cats-parse" % "0.2.0"
+libraryDependencies += "org.typelevel" %% "cats-parse" % "0.3.1"
 
 // use this snippet for JS, or cross-building
-libraryDependencies += "org.typelevel" %%% "cats-parse" % "0.2.0"
+libraryDependencies += "org.typelevel" %%% "cats-parse" % "0.3.1"
 ```
 
-The [API docs](https://oss.sonatype.org/service/local/repositories/releases/archive/org/typelevel/cats-parse_2.12/0.3.0/cats-parse_2.12-0.3.0-javadoc.jar/!/cats/parse/index.html) are published.
+The [API docs](https://oss.sonatype.org/service/local/repositories/releases/archive/org/typelevel/cats-parse_2.12/0.3.1/cats-parse_2.12-0.3.1-javadoc.jar/!/cats/parse/index.html) are published.
 
 Why another parsing library? See this [blog post detailing the
 design](https://posco.medium.com/designing-a-parsing-library-in-scala-d5076de52536). To reiterate,


### PR DESCRIPTION
Hi,

I just thought it might be useful to bump the versions in the README to the latest release version (0.3.1). `0.2.0` doesn't support Dotty so its inconsistent with the rest of the doc.

Thank you for contributing to `cats-parse`!

This is a kind reminder to run `sbt prePR` and commit the changed files, if any, before submitting.


