### PR TITLE
Support 2.11.12 by using old cats

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [3.0.0-RC2, 3.0.0-RC3, 2.12.13, 2.13.5]
+        scala: [3.0.0-RC2, 3.0.0-RC3, 2.11.12, 2.12.13, 2.13.5]
         java: [adopt@1.8]
     runs-on: ${{ matrix.os }}
     steps:
@@ -118,6 +118,16 @@ jobs:
           name: target-${{ matrix.os }}-3.0.0-RC3-${{ matrix.java }}
 
       - name: Inflate target directories (3.0.0-RC3)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
+
+      - name: Download target directories (2.11.12)
+        uses: actions/download-artifact@v2
+        with:
+          name: target-${{ matrix.os }}-2.11.12-${{ matrix.java }}
+
+      - name: Inflate target directories (2.11.12)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/build.sbt
+++ b/build.sbt
@@ -17,8 +17,7 @@ ThisBuild / publishFullName := "P. Oscar Boykin"
 ThisBuild / crossScalaVersions := List("3.0.0-RC2", "3.0.0-RC3", "2.11.12", "2.12.13", "2.13.5")
 
 ThisBuild / versionIntroduced := Map(
-  "3.0.0-M2" -> "0.1.99",
-  "3.0.0-M3" -> "0.1.99"
+  "2.11.12" -> "0.3.4"
 )
 
 ThisBuild / spiewakCiReleaseSnapshots := true
@@ -132,7 +131,8 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
     },
     scalacOptions ++= {
       val isScala211 = CrossVersion.partialVersion(scalaVersion.value).contains((2, 11))
-      if (isScala211) List("-Ypatmat-exhaust-depth 40") else Nil
+      // this code seems to trigger a bug in 2.11 pattern analysis
+      if (isScala211) List("-Xno-patmat-analysis") else Nil
     }
   )
   .settings(dottyJsSettings(ThisBuild / crossScalaVersions))

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ ThisBuild / organizationName := "Typelevel"
 ThisBuild / publishGithubUser := "johnynek"
 ThisBuild / publishFullName := "P. Oscar Boykin"
 
-ThisBuild / crossScalaVersions := List("3.0.0-RC2", "3.0.0-RC3", "2.12.13", "2.13.5")
+ThisBuild / crossScalaVersions := List("3.0.0-RC2", "3.0.0-RC3", "2.11.12", "2.12.13", "2.13.5")
 
 ThisBuild / versionIntroduced := Map(
   "3.0.0-M2" -> "0.1.99",
@@ -122,12 +122,15 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
   .crossType(CrossType.Full)
   .settings(
     name := "cats-parse",
-    libraryDependencies ++=
+    libraryDependencies ++= {
+      val partialVersion = CrossVersion.partialVersion(scalaVersion.value)
+      val isScala211 = partialVersion.contains((2, 11))
       Seq(
-        cats.value,
+        if (isScala211) cats211.value else cats.value,
         munit.value % Test,
         munitScalacheck.value % Test
       )
+    }
   )
   .settings(dottyJsSettings(ThisBuild / crossScalaVersions))
   .jsSettings(
@@ -150,7 +153,9 @@ lazy val bench = project
   .settings(
     name := "bench",
     coverageEnabled := false,
-    crossScalaVersions := (ThisBuild / crossScalaVersions).value.filter(_.startsWith("2.")),
+    crossScalaVersions := (ThisBuild / crossScalaVersions).value.filter { v =>
+      v.startsWith("2.12") || v.startsWith("2.13")
+    },
     libraryDependencies ++=
       Seq(
         fastParse,

--- a/build.sbt
+++ b/build.sbt
@@ -134,6 +134,7 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
   )
   .settings(dottyJsSettings(ThisBuild / crossScalaVersions))
   .jsSettings(
+    crossScalaVersions := (ThisBuild / crossScalaVersions).value.filterNot(_.startsWith("2.11")),
     Global / scalaJSStage := FastOptStage,
     parallelExecution := false,
     jsEnv := new org.scalajs.jsenv.nodejs.NodeJSEnv(),

--- a/build.sbt
+++ b/build.sbt
@@ -16,10 +16,6 @@ ThisBuild / publishFullName := "P. Oscar Boykin"
 
 ThisBuild / crossScalaVersions := List("3.0.0-RC2", "3.0.0-RC3", "2.11.12", "2.12.13", "2.13.5")
 
-ThisBuild / versionIntroduced := Map(
-  "2.11.12" -> "0.3.4"
-)
-
 ThisBuild / spiewakCiReleaseSnapshots := true
 
 ThisBuild / spiewakMainBranches := List("main")
@@ -133,6 +129,10 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
       val isScala211 = CrossVersion.partialVersion(scalaVersion.value).contains((2, 11))
       // this code seems to trigger a bug in 2.11 pattern analysis
       if (isScala211) List("-Xno-patmat-analysis") else Nil
+    },
+    mimaPreviousArtifacts := {
+      val isScala211 = CrossVersion.partialVersion(scalaVersion.value).contains((2, 11))
+      if (isScala211) Set.empty else mimaPreviousArtifacts.value
     }
   )
   .settings(dottyJsSettings(ThisBuild / crossScalaVersions))

--- a/build.sbt
+++ b/build.sbt
@@ -123,13 +123,16 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
   .settings(
     name := "cats-parse",
     libraryDependencies ++= {
-      val partialVersion = CrossVersion.partialVersion(scalaVersion.value)
-      val isScala211 = partialVersion.contains((2, 11))
+      val isScala211 = CrossVersion.partialVersion(scalaVersion.value).contains((2, 11))
       Seq(
         if (isScala211) cats211.value else cats.value,
         munit.value % Test,
         munitScalacheck.value % Test
       )
+    },
+    scalacOptions ++= {
+      val isScala211 = CrossVersion.partialVersion(scalaVersion.value).contains((2, 11))
+      if (isScala211) List("-Ypatmat-exhaust-depth 40") else Nil
     }
   )
   .settings(dottyJsSettings(ThisBuild / crossScalaVersions))

--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -1803,11 +1803,6 @@ object Parser {
       override def defer[A](pa: => Parser[A]): Parser[A] =
         Parser.this.defer(pa)
 
-      /*
-      override def fix[A](fn: Parser[A] => Parser[A]): Parser[A] =
-        Parser.recursive(fn)
-       */
-
       override def functor = this
 
       override def map[A, B](fa: Parser[A])(fn: A => B): Parser[B] =

--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -1803,8 +1803,10 @@ object Parser {
       override def defer[A](pa: => Parser[A]): Parser[A] =
         Parser.this.defer(pa)
 
+      /*
       override def fix[A](fn: Parser[A] => Parser[A]): Parser[A] =
         Parser.recursive(fn)
+       */
 
       override def functor = this
 
@@ -1816,9 +1818,6 @@ object Parser {
 
       override def filter[A](fa: Parser[A])(fn: A => Boolean): Parser[A] =
         fa.filter(fn)
-
-      override def filterNot[A](fa: Parser[A])(fn: A => Boolean): Parser[A] =
-        fa.filter { a => !fn(a) }
 
       override def flatMap[A, B](fa: Parser[A])(fn: A => Parser[B]): Parser[B] =
         Parser.this.flatMap10(fa)(fn)
@@ -2893,9 +2892,6 @@ object Parser0 {
 
       override def filter[A](fa: Parser0[A])(fn: A => Boolean): Parser0[A] =
         fa.filter(fn)
-
-      override def filterNot[A](fa: Parser0[A])(fn: A => Boolean): Parser0[A] =
-        fa.filter { a => !fn(a) }
 
       override def product[A, B](fa: Parser0[A], fb: Parser0[B]): Parser0[(A, B)] =
         Parser.product0(fa, fb)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,6 +3,7 @@ import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 
 object Dependencies {
   lazy val cats = Def.setting("org.typelevel" %%% "cats-core" % "2.6.0")
+  lazy val cats211 = Def.setting("org.typelevel" %%% "cats-core" % "2.0.0")
   lazy val munit = Def.setting("org.scalameta" %%% "munit" % "0.7.25")
   lazy val munitScalacheck = Def.setting("org.scalameta" %%% "munit-scalacheck" % "0.7.25")
   lazy val fastParse = "com.lihaoyi" %% "fastparse" % "2.3.2"


### PR DESCRIPTION
There a couple of minor costs here:

1. we lose an override of filterFunctor, but honestly we should send a PR to cats because the default implementation seems like it could be improved.
2. we lose an override of Defer.fix, which I doubt is very important.
3. We do not support scalajs on 2.11 since that's cutting really fine: there are a very small number of folks who want an old scala version AND scala js.

