### PR TITLE
Defer creation of Expectations

### DIFF
--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -68,7 +68,7 @@ sealed abstract class Parser0[+A] { self: Product =>
     val offset = state.offset
     if (err eq null) Right((str.substring(offset), result))
     else
-      Left(Parser.Error(offset, Parser.Expectation.unify(NonEmptyList.fromListUnsafe(err.toList))))
+      Left(Parser.Error(offset, Parser.Expectation.unify(NonEmptyList.fromListUnsafe(err.value.toList))))
   }
 
   /** Attempt to parse all of the input `str` into an `A` value.
@@ -92,7 +92,7 @@ sealed abstract class Parser0[+A] { self: Product =>
           )
         )
     } else
-      Left(Parser.Error(offset, Parser.Expectation.unify(NonEmptyList.fromListUnsafe(err.toList))))
+      Left(Parser.Error(offset, Parser.Expectation.unify(NonEmptyList.fromListUnsafe(err.value.toList))))
   }
 
   /** Convert epsilon failures into None values.
@@ -1773,7 +1773,7 @@ object Parser {
    */
   protected[parse] final class State(val str: String) {
     var offset: Int = 0
-    var error: Chain[Expectation] = null
+    var error: Eval[Chain[Expectation]] = null
     var capture: Boolean = true
   }
 
@@ -2033,7 +2033,7 @@ object Parser {
           state.offset = end
           res
         } else {
-          state.error = Chain.one(Expectation.Length(offset, len, state.str.length - offset))
+          state.error = Eval.later(Chain.one(Expectation.Length(offset, len, state.str.length - offset)))
           null
         }
       }
@@ -2079,8 +2079,9 @@ object Parser {
 
     case object StartParser extends Parser0[Unit] {
       override def parseMut(state: State): Unit = {
-        if (state.offset != 0) {
-          state.error = Chain.one(Expectation.StartOfString(state.offset))
+        val offset = state.offset
+        if (offset != 0) {
+          state.error = Eval.later(Chain.one(Expectation.StartOfString(offset)))
         }
         ()
       }
@@ -2088,8 +2089,9 @@ object Parser {
 
     case object EndParser extends Parser0[Unit] {
       override def parseMut(state: State): Unit = {
-        if (state.offset != state.str.length) {
-          state.error = Chain.one(Expectation.EndOfString(state.offset, state.str.length))
+        val offset = state.offset
+        if (offset != state.str.length) {
+          state.error = Eval.later(Chain.one(Expectation.EndOfString(offset, state.str.length)))
         }
         ()
       }
@@ -2128,7 +2130,7 @@ object Parser {
           state.offset += message.length
           ()
         } else {
-          state.error = Chain.one(Expectation.OneOfStr(offset, message :: Nil))
+          state.error = Eval.later(Chain.one(Expectation.OneOfStr(offset, message :: Nil)))
           ()
         }
       }
@@ -2144,7 +2146,7 @@ object Parser {
           state.offset += message.length
           ()
         } else {
-          state.error = Chain.one(Expectation.OneOfStr(offset, message :: Nil))
+          state.error = Eval.later(Chain.one(Expectation.OneOfStr(offset, message :: Nil)))
           ()
         }
       }
@@ -2152,21 +2154,23 @@ object Parser {
 
     case class Fail[A]() extends Parser[A] {
       override def parseMut(state: State): A = {
-        state.error = Chain.one(Expectation.Fail(state.offset));
+        val offset = state.offset
+        state.error = Eval.later(Chain.one(Expectation.Fail(offset)))
         null.asInstanceOf[A]
       }
     }
 
     case class FailWith[A](message: String) extends Parser[A] {
       override def parseMut(state: State): A = {
-        state.error = Chain.one(Expectation.FailWith(state.offset, message));
+        val offset = state.offset
+        state.error = Eval.later(Chain.one(Expectation.FailWith(offset, message)))
         null.asInstanceOf[A]
       }
     }
 
     final def oneOf[A](all: Array[Parser0[A]], state: State): A = {
       val offset = state.offset
-      var errs: Chain[Expectation] = Chain.nil
+      var errs: Eval[Chain[Expectation]] = Eval.later(Chain.nil)
       var idx = 0
       while (idx < all.length) {
         val thisParser = all(idx)
@@ -2180,7 +2184,7 @@ object Parser {
           // we failed to parse, but didn't consume input
           // is unchanged we continue
           // else we stop
-          errs = errs ++ err
+          errs = errs.map(_ ++ err.value)
           state.error = null
           idx = idx + 1
         }
@@ -2221,7 +2225,7 @@ object Parser {
         }
       }
       if (lastMatch < 0) {
-        state.error = Chain.one(Expectation.OneOfStr(startOffset, all.toList))
+        state.error = Eval.later(Chain.one(Expectation.OneOfStr(startOffset, all.toList)))
         state.offset = startOffset
       } else {
         state.offset = lastMatch
@@ -2645,7 +2649,7 @@ object Parser {
           state.offset += 1
           char
         } else {
-          state.error = Chain.one(Expectation.InRange(offset, Char.MinValue, Char.MaxValue))
+          state.error = Eval.later(Chain.one(Expectation.InRange(offset, Char.MinValue, Char.MaxValue)))
           '\u0000'
         }
       }
@@ -2656,15 +2660,12 @@ object Parser {
 
       override def toString = s"CharIn($min, bitSet = ..., $ranges)"
 
-      def makeError(offset: Int): Chain[Expectation] = {
-        var result = Chain.empty[Expectation]
-        var aux = ranges.toList
-        while (aux.nonEmpty) {
-          val (s, e) = aux.head
-          result = result :+ Expectation.InRange(offset, s, e)
-          aux = aux.tail
-        }
-        result
+      def makeError(offset: Int): Eval[Chain[Expectation]] = {
+        Eval.later(Chain.fromSeq(
+          ranges.toList.map { case (s, e) =>
+            Expectation.InRange(offset, s, e)
+          }
+        ))
       }
 
       override def parseMut(state: State): Char = {
@@ -2703,7 +2704,7 @@ object Parser {
           val matchedStr = state.str.substring(offset, state.offset)
           // we don't reset the offset, so if the underlying parser
           // advanced it will fail in a OneOf
-          state.error = Chain.one(Expectation.ExpectedFailureAt(offset, matchedStr))
+          state.error = Eval.later(Chain.one(Expectation.ExpectedFailureAt(offset, matchedStr)))
         }
 
         state.offset = offset
@@ -2732,7 +2733,7 @@ object Parser {
       override def parseMut(state: State): A = {
         val a = under.parseMut(state)
         if (state.error ne null) {
-          state.error = state.error.map(Expectation.WithContext(context, _))
+          state.error = state.error.map(_.map(Expectation.WithContext(context, _)))
         }
         a
       }
@@ -2742,7 +2743,7 @@ object Parser {
       override def parseMut(state: State): A = {
         val a = under.parseMut(state)
         if (state.error ne null) {
-          state.error = state.error.map(Expectation.WithContext(context, _))
+          state.error = state.error.map(_.map(Expectation.WithContext(context, _)))
         }
         a
       }


### PR DESCRIPTION
Given a parser whose hot part looks like this:

```scala
    val fieldName = Rfc7230.token.string
    val fieldValue = P.repSep0(Rfc5234.vchar.rep, P.charIn(" \t").rep).string.surroundedBy(Rfc7230.ows)
    val header = ((fieldName <* P.char(':')) ~ fieldValue).map {
      case (k, v) => Header.Raw(CIString(k), v)
    }
    val headers = (header <* P.string("\r\n")).rep0
```

`CharIn.makeError` is dominating the stack trace and allocations.  It is created at the end of each repetition, only to be nulled out and gc'ed if we've made any progress.

```
[info] Benchmark                                                         Mode  Cnt       Score       Error   Units
[info] Http1DecoderBench.http1Decoder                                   thrpt    5  194717.904 ± 27142.805   ops/s
[info] Http1DecoderBench.http1Decoder:·gc.alloc.rate                    thrpt    5    2375.264 ±   330.882  MB/sec
[info] Http1DecoderBench.http1Decoder:·gc.alloc.rate.norm               thrpt    5   13436.503 ±     0.524    B/op
[info] Http1DecoderBench.http1Decoder:·gc.churn.G1_Eden_Space           thrpt    5    2378.683 ±   323.143  MB/sec
[info] Http1DecoderBench.http1Decoder:·gc.churn.G1_Eden_Space.norm      thrpt    5   13456.252 ±   205.497    B/op
[info] Http1DecoderBench.http1Decoder:·gc.churn.G1_Survivor_Space       thrpt    5       0.008 ±     0.004  MB/sec
[info] Http1DecoderBench.http1Decoder:·gc.churn.G1_Survivor_Space.norm  thrpt    5       0.044 ±     0.019    B/op
[info] Http1DecoderBench.http1Decoder:·gc.count                         thrpt    5     508.000              counts
[info] Http1DecoderBench.http1Decoder:·gc.time                          thrpt    5     552.000                  ms
[info] Http1DecoderBench.http1Decoder:·stack                            thrpt              NaN                 ---
```

Here, we wrap every `Chain[Expectation]` in an `Eval`, so that the expectations can be created lazily.  Care must be taken not to close over mutable state, namely, `state.offset`.  We significantly increase speed and reduce garbage:

```
[info] Http1DecoderBench.http1Decoder                                   thrpt    5  353576.391 ± 39077.640   ops/s
[info] Http1DecoderBench.http1Decoder:·gc.alloc.rate                    thrpt    5    2293.983 ±   253.014  MB/sec
[info] Http1DecoderBench.http1Decoder:·gc.alloc.rate.norm               thrpt    5    7146.434 ±     0.264    B/op
[info] Http1DecoderBench.http1Decoder:·gc.churn.G1_Eden_Space           thrpt    5    2294.376 ±   247.756  MB/sec
[info] Http1DecoderBench.http1Decoder:·gc.churn.G1_Eden_Space.norm      thrpt    5    7147.791 ±    94.745    B/op
[info] Http1DecoderBench.http1Decoder:·gc.churn.G1_Survivor_Space       thrpt    5       0.007 ±     0.002  MB/sec
[info] Http1DecoderBench.http1Decoder:·gc.churn.G1_Survivor_Space.norm  thrpt    5       0.023 ±     0.006    B/op
[info] Http1DecoderBench.http1Decoder:·gc.count                         thrpt    5     494.000              counts
[info] Http1DecoderBench.http1Decoder:·gc.time                          thrpt    5     519.000                  ms
[info] Http1DecoderBench.http1Decoder:·stack                            thrpt              NaN                 ---
```

I'll work on cleaning up and providing a runnable benchmark, but wanted to get early feedback.

We might also make it leaner with simple thunks rather than an `Eval` that's always `later`.