### PR TITLE
Optimize charWhere for Sets

### DIFF
--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -1482,7 +1482,13 @@ object Parser {
   /** parse one character that matches a given function
     */
   def charWhere(fn: Char => Boolean): Parser[Char] =
-    charIn(Impl.allChars.filter(fn))
+    fn match {
+      case s: Set[Char] =>
+        // Set extends function, but it is also iterable
+        charIn(s)
+      case _ =>
+        charIn(Impl.allChars.filter(fn))
+    }
 
   /** Parse a string while the given function is true
     */

--- a/core/shared/src/test/scala/cats/parse/ParserTest.scala
+++ b/core/shared/src/test/scala/cats/parse/ParserTest.scala
@@ -2383,4 +2383,10 @@ class ParserTest extends munit.ScalaCheckSuite {
         }
     }
   }
+
+  property("a parser from a set of chars is the same with charWhere/charIn") {
+    forAll { (input: String, chars: Set[Char]) =>
+      assertEquals(Parser.charWhere(chars).parse(input), Parser.charIn(chars).parse(input))
+    }
+  }
 }


### PR DESCRIPTION
Since `Set[Char]` extends `Char => Boolean` but we can also enumerate it directly, we can directly call `charIn` rather than exhaustively checking the function.