### PR TITLE
Add .soft.between and .soft.surroundedBy

### DIFF
--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -886,6 +886,19 @@ object Parser {
       */
     def with1: Soft01[A] =
       new Soft01(parser)
+
+    /** Like regular between, but uses soft products This is particularly useful with whitespace and
+      * separators, e.g. a separator might be `char(',').soft.surroundedBy(whitespace0)`
+      */
+    def between(b: Parser0[Any], c: Parser0[Any]): Parser0[A] =
+      (b.void.soft ~ (parser.soft ~ c.void)).map { case (_, (a, _)) => a }
+
+    /** Use this parser to parse surrounded by values using soft products
+      *
+      * This is the same as `between(b, b)`
+      */
+    def surroundedBy(b: Parser0[Any]): Parser0[A] =
+      between(b, b)
   }
 
   /** If we can parse this then that, do so, if we fail that without consuming, rewind before this
@@ -900,6 +913,12 @@ object Parser {
 
     override def <*[B](that: Parser0[B]): Parser[A] =
       softProduct10(parser, void0(that)).map(_._1)
+
+    override def between(b: Parser0[Any], c: Parser0[Any]): Parser[A] =
+      (b.void.with1.soft ~ (parser.soft ~ c.void)).map { case (_, (a, _)) => a }
+
+    override def surroundedBy(b: Parser0[Any]): Parser[A] =
+      between(b, b)
   }
 
   /** If we can parse this then that, do so, if we fail that without consuming, rewind before this

--- a/core/shared/src/test/scala/cats/parse/ParserTest.scala
+++ b/core/shared/src/test/scala/cats/parse/ParserTest.scala
@@ -1489,6 +1489,44 @@ class ParserTest extends munit.ScalaCheckSuite {
     }
   }
 
+  property("parse soft.between open and close") {
+    forAll(ParserGen.gen0, ParserGen.gen0, ParserGen.gen0, Arbitrary.arbitrary[String]) {
+      (genP1, genP, genQ, str) =>
+        val pa = genP1.fa.soft.between(genP.fa, genQ.fa)
+        val pb = genP.fa.soft *> (genP1.fa.soft <* genQ.fa)
+
+        assertEquals(pa.parse(str), pb.parse(str))
+    }
+  }
+
+  property("soft.surroundedBy consistent with soft.between") {
+    forAll(ParserGen.gen0, ParserGen.gen0, Arbitrary.arbitrary[String]) { (genP1, genP, str) =>
+      val pa = genP1.fa.soft.between(genP.fa, genP.fa)
+      val pb = genP1.fa.soft.surroundedBy(genP.fa)
+
+      assertEquals(pa.parse(str), pb.parse(str))
+    }
+  }
+
+  property("parse soft.between open and close with Parser this") {
+    forAll(ParserGen.gen, ParserGen.gen0, ParserGen.gen0, Arbitrary.arbitrary[String]) {
+      (genP1, genP, genQ, str) =>
+        val pa = genP1.fa.soft.between(genP.fa, genQ.fa)
+        val pb = genP.fa.soft *> (genP1.fa.soft <* genQ.fa)
+
+        assertEquals(pa.parse(str), pb.parse(str))
+    }
+  }
+
+  property("soft.surroundedBy consistent with between with Parser this") {
+    forAll(ParserGen.gen, ParserGen.gen0, Arbitrary.arbitrary[String]) { (genP1, genP, str) =>
+      val pa = genP1.fa.soft.between(genP.fa, genP.fa)
+      val pb = genP1.fa.soft.surroundedBy(genP.fa)
+
+      assertEquals(pa.parse(str), pb.parse(str))
+    }
+  }
+
   property("parse between open and close with Parser args") {
     forAll(ParserGen.gen0, ParserGen.gen, ParserGen.gen, Arbitrary.arbitrary[String]) {
       (genP1, genP, genQ, str) =>

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -52,7 +52,7 @@ object Json {
     val num = Numbers.jsonNumber.map(JNum(_))
 
     val listSep: P[Unit] =
-      (whitespaces0.with1.soft ~ P.char(',') ~ whitespaces0).void
+      P.char(',').soft.surroundedBy(whitespaces0).void
 
     def rep[A](pa: P[A]): Parser0[List[A]] =
       pa.repSep0(listSep).surroundedBy(whitespaces0)


### PR DESCRIPTION
address the kinds of errors seen here:

https://github.com/typelevel/cats-parse/issues/272#issuecomment-932541128