### PR TITLE
Improve merging of Char parsers

### DIFF
--- a/core/js/src/main/scala/cats/parse/BitSet.scala
+++ b/core/js/src/main/scala/cats/parse/BitSet.scala
@@ -51,6 +51,6 @@ object BitSetUtil {
     def toIter(m: Int, bs: BitSet): Iterator[Char] =
       bs.iterator.map { i => (i + m).toChar } ++ Iterator.single(m.toChar)
 
-    bs.flatMap { case (m, bs) => toIter(m, bs) }
+    bs.iterator.flatMap { case (m, bs) => toIter(m, bs) }.toSet
   }
 }

--- a/core/jvm/src/main/scala/cats/parse/BitSet.scala
+++ b/core/jvm/src/main/scala/cats/parse/BitSet.scala
@@ -56,6 +56,6 @@ object BitSetUtil {
         .takeWhile(_ >= 0)
         .map { i => (m + i).toChar }
 
-    bs.flatMap { case (m, bs) => toIter(m, bs) }
+    bs.iterator.flatMap { case (m, bs) => toIter(m, bs) }.toSet
   }
 }

--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -2622,7 +2622,7 @@ object Parser {
             // and any direct prefix CharIns
             val tail1 = tail.filterNot(_.isInstanceOf[CharIn])
             (result :+ AnyChar.asInstanceOf[P0]) ++ Chain.fromSeq(tail1)
-          case (ci @ CharIn(_, _, _)) :: tail =>
+          case (ci: CharIn) :: tail =>
             loop(tail, ci :: front, result)
           case h :: tail =>
             // h is not an AnyChar or CharIn

--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -2603,11 +2603,17 @@ object Parser {
      */
     def mergeCharIn[A, P0 <: Parser0[A]](ps: List[P0]): List[P0] = {
       @annotation.tailrec
-      def loop(ps: List[P0], front: List[(Int, BitSetUtil.Tpe)], result: Chain[P0]): Chain[P0] = {
+      def loop(ps: List[P0], front: List[CharIn], result: Chain[P0]): Chain[P0] = {
         @inline
         def frontRes: Chain[P0] =
-          if (front.isEmpty) Chain.nil
-          else Chain.one(Parser.charIn(BitSetUtil.union(front)).asInstanceOf[P0])
+          front match {
+            case Nil => Chain.nil
+            case one :: Nil => Chain.one(one.asInstanceOf[P0])
+            case many =>
+              // we need to union
+              val minBs: List[(Int, BitSetUtil.Tpe)] = many.map { case CharIn(m, bs, _) => (m, bs) }
+              Chain.one(Parser.charIn(BitSetUtil.union(minBs)).asInstanceOf[P0])
+          }
 
         ps match {
           case Nil => result ++ frontRes
@@ -2616,8 +2622,8 @@ object Parser {
             // and any direct prefix CharIns
             val tail1 = tail.filterNot(_.isInstanceOf[CharIn])
             (result :+ AnyChar.asInstanceOf[P0]) ++ Chain.fromSeq(tail1)
-          case CharIn(m, bs, _) :: tail =>
-            loop(tail, (m, bs) :: front, result)
+          case (ci @ CharIn(_, _, _)) :: tail =>
+            loop(tail, ci :: front, result)
           case h :: tail =>
             // h is not an AnyChar or CharIn
             // we make our prefix frontRes


### PR DESCRIPTION
1. If we have a single CharIn parser, we don't need to compute the union, just reuse it (which also saves recomputing the range of characters)
2. return a Set in the union function, not a List, which can return a large list if you have duplicates in your set.