### PR TITLE
Fix issue 263

### DIFF
--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -2266,14 +2266,14 @@ object Parser {
           // we failed to parse, but didn't consume input
           // is unchanged we continue
           // else we stop
-          errs = for { e1 <- errs; e2 <- err } yield filterFails(offset, e1 ++ e2)
+          errs = for { e1 <- errs; e2 <- err } yield e1 ++ e2
           state.error = null
           idx = idx + 1
         }
       }
       // if we got here, all of them failed, but we
       // never advanced the offset
-      state.error = errs
+      state.error = errs.map(filterFails(offset, _))
       null.asInstanceOf[A]
     }
 

--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -2243,7 +2243,7 @@ object Parser {
      */
     final def filterFails(offset: Int, fs: Chain[Expectation]): Chain[Expectation] = {
       val fs1 = fs.filter {
-        case Expectation.Fail(_) => false
+        case Expectation.Fail(o) if o == offset => false
         case _ => true
       }
       if (fs1.isEmpty) Chain.one(Expectation.Fail(offset))

--- a/core/shared/src/test/scala/cats/parse/ParserTest.scala
+++ b/core/shared/src/test/scala/cats/parse/ParserTest.scala
@@ -826,7 +826,7 @@ class ParserTest extends munit.ScalaCheckSuite {
               if (err1.failedAtOffset == 0) {
                 val errs = err.expected ::: err1.expected
                 NonEmptyList.fromList(errs.filter {
-                  case Parser.Expectation.Fail(_) => false
+                  case Parser.Expectation.Fail(0) => false
                   case _ => true
                 }) match {
                     case None =>

--- a/core/shared/src/test/scala/cats/parse/ParserTest.scala
+++ b/core/shared/src/test/scala/cats/parse/ParserTest.scala
@@ -602,11 +602,11 @@ class ParserTest extends munit.ScalaCheckSuite {
       .withMinSuccessfulTests(tests)
       .withMaxDiscardRatio(10)
 
-  //override val scalaCheckInitialSeed =
-    // past regressions that we can check periodically
-    //"bUQvEfxFZ73bxtVjauK8tJDrEKOFbxUfk6WrGiy3bkH="
-    //"PPsKExr4HRlyCXkMrC6Rki5u59V88vwSeVTiGWJFS3G="
-    //"Ova1uT18mkE4uTX4RdgQza6z70fxyv6micl4hIZvywP="
+  // override val scalaCheckInitialSeed =
+  // past regressions that we can check periodically
+  // "bUQvEfxFZ73bxtVjauK8tJDrEKOFbxUfk6WrGiy3bkH="
+  // "PPsKExr4HRlyCXkMrC6Rki5u59V88vwSeVTiGWJFS3G="
+  // "Ova1uT18mkE4uTX4RdgQza6z70fxyv6micl4hIZvywP="
 
   def parseTest[A: Eq](p: Parser0[A], str: String, a: A) =
     p.parse(str) match {
@@ -829,11 +829,11 @@ class ParserTest extends munit.ScalaCheckSuite {
                   case Parser.Expectation.Fail(0) => false
                   case _ => true
                 }) match {
-                    case None =>
-                      Parser.Error(0, NonEmptyList(Parser.Expectation.Fail(0), Nil))
-                    case Some(nel) =>
-                      Parser.Error(err1.failedAtOffset, Parser.Expectation.unify(nel))
-                  }
+                  case None =>
+                    Parser.Error(0, NonEmptyList(Parser.Expectation.Fail(0), Nil))
+                  case Some(nel) =>
+                    Parser.Error(err1.failedAtOffset, Parser.Expectation.unify(nel))
+                }
               } else err1
             }
         } else left

--- a/core/shared/src/test/scala/cats/parse/ParserTest.scala
+++ b/core/shared/src/test/scala/cats/parse/ParserTest.scala
@@ -2112,6 +2112,15 @@ class ParserTest extends munit.ScalaCheckSuite {
     }
   }
 
+  property("a Parser never succeeds and does not advance") {
+    forAll(ParserGen.gen, Arbitrary.arbitrary[String]) { (genP, str) =>
+      genP.fa.parse(str) match {
+        case Right((rest, _)) => assertNotEquals(rest, str)
+        case Left(_) => ()
+      }
+    }
+  }
+
   property("select on pure values works as expected") {
     forAll { (left: Option[Either[Int, String]], right: Option[Int => String], str: String) =>
       val pleft = left match {

--- a/core/shared/src/test/scala/cats/parse/ParserTest.scala
+++ b/core/shared/src/test/scala/cats/parse/ParserTest.scala
@@ -602,6 +602,12 @@ class ParserTest extends munit.ScalaCheckSuite {
       .withMinSuccessfulTests(tests)
       .withMaxDiscardRatio(10)
 
+  //override val scalaCheckInitialSeed =
+    // past regressions that we can check periodically
+    //"bUQvEfxFZ73bxtVjauK8tJDrEKOFbxUfk6WrGiy3bkH="
+    //"PPsKExr4HRlyCXkMrC6Rki5u59V88vwSeVTiGWJFS3G="
+    //"Ova1uT18mkE4uTX4RdgQza6z70fxyv6micl4hIZvywP="
+
   def parseTest[A: Eq](p: Parser0[A], str: String, a: A) =
     p.parse(str) match {
       case Right((_, res)) =>
@@ -811,24 +817,28 @@ class ParserTest extends munit.ScalaCheckSuite {
     }
   }
 
-  def orElse[A](p1: Parser0[A], p2: Parser0[A], str: String): Either[Parser.Error, (String, A)] = {
-    if (p1 == Parser.Fail) p2.parse(str)
-    else if (p2 == Parser.Fail) p1.parse(str)
-    else
-      p1.parse(str) match {
-        case left @ Left(err) =>
-          if (err.failedAtOffset == 0) {
-            p2.parse(str)
-              .leftMap { err1 =>
-                if (err1.failedAtOffset == 0) {
-                  val errs = err.expected ::: err1.expected
-                  Parser.Error(err1.failedAtOffset, Parser.Expectation.unify(errs))
-                } else err1
-              }
-          } else left
-        case right => right
-      }
-  }
+  def orElse[A](p1: Parser0[A], p2: Parser0[A], str: String): Either[Parser.Error, (String, A)] =
+    p1.parse(str) match {
+      case left @ Left(err) =>
+        if (err.failedAtOffset == 0) {
+          p2.parse(str)
+            .leftMap { err1 =>
+              if (err1.failedAtOffset == 0) {
+                val errs = err.expected ::: err1.expected
+                NonEmptyList.fromList(errs.filter {
+                  case Parser.Expectation.Fail(_) => false
+                  case _ => true
+                }) match {
+                    case None =>
+                      Parser.Error(0, NonEmptyList(Parser.Expectation.Fail(0), Nil))
+                    case Some(nel) =>
+                      Parser.Error(err1.failedAtOffset, Parser.Expectation.unify(nel))
+                  }
+              } else err1
+            }
+        } else left
+      case right => right
+    }
 
   property("oneOf0 composes as expected") {
     forAll(ParserGen.gen0, ParserGen.gen0, Arbitrary.arbitrary[String]) { (genP1, genP2, str) =>
@@ -1429,11 +1439,11 @@ class ParserTest extends munit.ScalaCheckSuite {
   property("with1 *> and with1 <* work as expected") {
     forAll(ParserGen.gen0, ParserGen.gen, Arbitrary.arbitrary[String]) { (p1, p2, str) =>
       val rp1 = p1.fa.with1 *> p2.fa
-      val rp2 = (p1.fa.with1 ~ p2.fa).map(_._2)
+      val rp2 = (p1.fa.void.with1 ~ p2.fa).map(_._2)
       assertEquals(rp1.parse(str), rp2.parse(str))
 
       val rp3 = p1.fa.with1 <* p2.fa
-      val rp4 = (p1.fa.with1 ~ p2.fa).map(_._1)
+      val rp4 = (p1.fa.with1 ~ p2.fa.void).map(_._1)
       assertEquals(rp3.parse(str), rp4.parse(str))
     }
   }


### PR DESCRIPTION
close #263 

I made sure all the previous failures are no longer failures.

This fixes in a couple of ways:

1. add some of the static optimizations that we hit on some, but not all code paths
2. change some of the laws to relax them somewhat (mostly around overly strict equivalences in error cases)

This should be performance neutral or possibly slightly faster.