### PR TITLE
Make sure void is idempotent

### DIFF
--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -1968,7 +1968,10 @@ object Parser {
               else SoftProd0(u1, u2)
           }
         case Defer0(fn) =>
-          Defer0(UnmapDefer0(fn))
+          fn match {
+            case UnmapDefer0(_) => pa // already unmapped
+            case _ => Defer0(UnmapDefer0(fn))
+          }
         case Rep0(p, max, _) => Rep0(unmap(p), max, Accumulator0.unitAccumulator0)
         case WithContextP0(ctx, p0) => WithContextP0(ctx, unmap0(p0))
         case StartParser | EndParser | TailRecM0(_, _) | FlatMap0(_, _) =>
@@ -2049,7 +2052,10 @@ object Parser {
               else SoftProd(u1, u2)
           }
         case Defer(fn) =>
-          Defer(UnmapDefer(fn))
+          fn match {
+            case UnmapDefer(_) => pa // already unmapped
+            case _ => Defer(UnmapDefer(fn))
+          }
         case Rep(p, min, max, _) => Rep(unmap(p), min, max, Accumulator0.unitAccumulator0)
         case WithContextP(ctx, p) =>
           WithContextP(ctx, unmap(p))

--- a/core/shared/src/test/scala/cats/parse/ParserTest.scala
+++ b/core/shared/src/test/scala/cats/parse/ParserTest.scala
@@ -2446,4 +2446,18 @@ class ParserTest extends munit.ScalaCheckSuite {
       assertEquals(Parser.charWhere(chars).parse(input), Parser.charIn(chars).parse(input))
     }
   }
+
+  property("P0.void is idempotent") {
+    forAll(ParserGen.gen0) { p =>
+      val v1 = p.fa.void
+      assertEquals(v1.void, v1)
+    }
+  }
+
+  property("P.void is idempotent") {
+    forAll(ParserGen.gen) { p =>
+      val v1 = p.fa.void
+      assertEquals(v1.void, v1)
+    }
+  }
 }


### PR DESCRIPTION
This adds a law (that actually already passed), and makes unmap a bit more precise in the case of Defer.