### PR TITLE
Add Parser.caret

### DIFF
--- a/core/shared/src/main/scala/cats/parse/Caret.scala
+++ b/core/shared/src/main/scala/cats/parse/Caret.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2021 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package cats.parse
+
+import cats.Order
+
+/** This is a pointer to a zero based row, column, and total offset.
+  */
+case class Caret(row: Int, col: Int, offset: Int)
+
+object Caret {
+  val Start: Caret = Caret(0, 0, 0)
+
+  implicit val caretOrder: Order[Caret] =
+    new Order[Caret] {
+      def compare(left: Caret, right: Caret): Int = {
+        val c0 = Integer.compare(left.row, right.row)
+        if (c0 != 0) c0
+        else {
+          val c1 = Integer.compare(left.col, right.col)
+          if (c1 != 0) c1
+          else Integer.compare(left.offset, right.offset)
+        }
+      }
+    }
+
+  implicit val caretOrdering: Ordering[Caret] =
+    caretOrder.toOrdering
+}

--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -1608,7 +1608,7 @@ object Parser {
       case str if Impl.matchesString(str) => str.asInstanceOf[Parser0[String]]
       case _ =>
         Impl.unmap0(pa) match {
-          case Impl.Pure(_) | Impl.Index => emptyStringParser0
+          case Impl.Pure(_) | Impl.Index | Impl.GetCaret => emptyStringParser0
           case notEmpty => Impl.StringP0(notEmpty)
         }
     }
@@ -1662,6 +1662,11 @@ object Parser {
     */
   def index: Parser0[Int] = Impl.Index
 
+  /** return the current Caret (offset, line, column) this is a bit more expensive that just the
+    * index
+    */
+  def caret: Parser0[Caret] = Impl.GetCaret
+
   /** succeeds when we are at the start
     */
   def start: Parser0[Unit] = Impl.StartParser
@@ -1696,7 +1701,7 @@ object Parser {
       case p1: Parser[_] => as(p1, b)
       case _ =>
         Impl.unmap0(pa) match {
-          case Impl.Pure(_) | Impl.Index => pure(b)
+          case Impl.Pure(_) | Impl.Index | Impl.GetCaret => pure(b)
           case notPure =>
             Impl.Void0(notPure).map(Impl.ConstFn(b))
         }
@@ -1816,6 +1821,10 @@ object Parser {
     var offset: Int = 0
     var error: Eval[Chain[Expectation]] = null
     var capture: Boolean = true
+
+    // This is lazy because we don't want to trigger it
+    // unless someone uses GetCaret
+    lazy val locationMap: LocationMap = LocationMap(str)
   }
 
   // invariant: input must be sorted
@@ -1864,8 +1873,9 @@ object Parser {
     final def doesBacktrack(p: Parser0[Any]): Boolean =
       p match {
         case Backtrack0(_) | Backtrack(_) | AnyChar | CharIn(_, _, _) | Str(_) | IgnoreCase(_) |
-            Length(_) | StartParser | EndParser | Index | Pure(_) | Fail() | FailWith(_) | Not(_) |
-            StringIn(_) =>
+            Length(_) | StartParser | EndParser | Index | GetCaret | Pure(_) | Fail() | FailWith(
+              _
+            ) | Not(_) | StringIn(_) =>
           true
         case Map0(p, _) => doesBacktrack(p)
         case Map(p, _) => doesBacktrack(p)
@@ -1895,7 +1905,7 @@ object Parser {
     // and by construction, a oneOf0 never always succeeds
     final def alwaysSucceeds(p: Parser0[Any]): Boolean =
       p match {
-        case Index | Pure(_) => true
+        case Index | GetCaret | Pure(_) => true
         case Map0(p, _) => alwaysSucceeds(p)
         case SoftProd0(a, b) => alwaysSucceeds(a) && alwaysSucceeds(b)
         case Prod0(a, b) => alwaysSucceeds(a) && alwaysSucceeds(b)
@@ -1913,7 +1923,7 @@ object Parser {
     def unmap0(pa: Parser0[Any]): Parser0[Any] =
       pa match {
         case p1: Parser[Any] => unmap(p1)
-        case Pure(_) | Index => Parser.unit
+        case GetCaret | Index | Pure(_) => Parser.unit
         case s if alwaysSucceeds(s) => Parser.unit
         case Map0(p, _) =>
           // we discard any allocations done by fn
@@ -2149,6 +2159,12 @@ object Parser {
 
     case object Index extends Parser0[Int] {
       override def parseMut(state: State): Int = state.offset
+    }
+
+    case object GetCaret extends Parser0[Caret] {
+      override def parseMut(state: State): Caret =
+        // This unsafe call is safe because the offset can never go too far
+        state.locationMap.toCaretUnsafe(state.offset)
     }
 
     final def backtrack[A](pa: Parser0[A], state: State): A = {

--- a/core/shared/src/test/scala/cats/parse/ParserTest.scala
+++ b/core/shared/src/test/scala/cats/parse/ParserTest.scala
@@ -71,7 +71,9 @@ object ParserGen {
     }
 
   implicit val cogenCaret: Cogen[Caret] =
-    Cogen { case Caret(o, row, col) => (o.toLong << 32) | (col.toLong << 16) | (row.toLong) }
+    Cogen { caret: Caret =>
+      (caret.offset.toLong << 32) | (caret.col.toLong << 16) | (caret.row.toLong)
+    }
 
   def arbGen[A: Arbitrary: Cogen]: GenT[Gen] =
     GenT(Arbitrary.arbitrary[A])

--- a/core/shared/src/test/scala/cats/parse/ParserTest.scala
+++ b/core/shared/src/test/scala/cats/parse/ParserTest.scala
@@ -70,6 +70,9 @@ object ParserGen {
       def map[A, B](ga: Gen[A])(fn: A => B) = ga.map(fn)
     }
 
+  implicit val cogenCaret: Cogen[Caret] =
+    Cogen { case Caret(o, row, col) => (o.toLong << 32) | (col.toLong << 16) | (row.toLong) }
+
   def arbGen[A: Arbitrary: Cogen]: GenT[Gen] =
     GenT(Arbitrary.arbitrary[A])
 
@@ -516,7 +519,7 @@ object ParserGen {
       (5, expect0),
       (1, ignoreCase0),
       (5, charIn0),
-      (1, Gen.oneOf(GenT(Parser.start), GenT(Parser.end), GenT(Parser.index))),
+      (1, Gen.oneOf(GenT(Parser.start), GenT(Parser.end), GenT(Parser.index), GenT(Parser.caret))),
       (1, fail),
       (1, failWith),
       (1, rec.map(void0(_))),
@@ -2458,6 +2461,16 @@ class ParserTest extends munit.ScalaCheckSuite {
     forAll(ParserGen.gen) { p =>
       val v1 = p.fa.void
       assertEquals(v1.void, v1)
+    }
+  }
+
+  property("P.caret is the same as index + toCaretUnsafe") {
+    forAll(ParserGen.gen, Arbitrary.arbitrary[String]) { (p, input) =>
+      val v1 = p.fa.void
+      val lm = LocationMap(input)
+      val left = (v1 *> Parser.index).map(lm.toCaretUnsafe(_)).parse(input)
+      val right = (v1 *> Parser.caret).parse(input)
+      assertEquals(left, right)
     }
   }
 }


### PR DESCRIPTION
This does the caret part of #238 

related to #234 

I did not add Span, just Caret.

My concern was that the span methods are a bit less clear. For instance, we may want an inclusive upper bound range, or maybe we do want exclusive. Inclusive is a bit more complex to implement however.

To sidestep this concern for now while we think about the design, I just added getting the `Caret` itself.

cc @re-xyr