### PR TITLE
Remove mima exclusion

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -134,12 +134,7 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
     mimaPreviousArtifacts := {
       val isScala211 = CrossVersion.partialVersion(scalaVersion.value).contains((2, 11))
       if (isScala211) Set.empty else mimaPreviousArtifacts.value
-    },
-    mimaBinaryIssueFilters := Seq(
-      ProblemFilters.exclude[IncompatibleResultTypeProblem](
-        "cats.parse.Parser#Impl#CharIn.makeError"
-      ) // Impl is private to cats.parse.Parser
-    )
+    }
   )
   .jsSettings(
     crossScalaVersions := (ThisBuild / crossScalaVersions).value.filterNot(_.startsWith("2.11")),

--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -2717,17 +2717,15 @@ object Parser {
 
       override def toString = s"CharIn($min, bitSet = ..., $ranges)"
 
-      def makeError(offset: Int): Eval[Chain[Expectation]] = {
-        Eval.later {
-          var result = Chain.empty[Expectation]
-          var aux = ranges.toList
-          while (aux.nonEmpty) {
-            val (s, e) = aux.head
-            result = result :+ Expectation.InRange(offset, s, e)
-            aux = aux.tail
-          }
-          result
+      def makeError(offset: Int): Chain[Expectation] = {
+        var result = Chain.empty[Expectation]
+        var aux = ranges.toList
+        while (aux.nonEmpty) {
+          val (s, e) = aux.head
+          result = result :+ Expectation.InRange(offset, s, e)
+          aux = aux.tail
         }
+        result
       }
 
       override def parseMut(state: State): Char = {
@@ -2740,11 +2738,11 @@ object Parser {
             state.offset = offset + 1
             char
           } else {
-            state.error = makeError(offset)
+            state.error = Eval.later(makeError(offset))
             '\u0000'
           }
         } else {
-          state.error = makeError(offset)
+          state.error = Eval.later(makeError(offset))
           '\u0000'
         }
       }


### PR DESCRIPTION
By putting the call to `makeError` inside `Eval.later` we can avoid the mima exclusion, which simplifies the build.

This is in preparation for publishing a new version hopefully today.