### PR TITLE
Fix some minor issues before 0.3.5

### DIFF
--- a/core/shared/src/main/scala/cats/parse/Caret.scala
+++ b/core/shared/src/main/scala/cats/parse/Caret.scala
@@ -23,9 +23,9 @@ package cats.parse
 
 import cats.Order
 
-/** This is a pointer to a zero based row, column, and total offset.
+/** This is a pointer to a zero based line, column, and total offset.
   */
-case class Caret(row: Int, col: Int, offset: Int)
+case class Caret(line: Int, col: Int, offset: Int)
 
 object Caret {
   val Start: Caret = Caret(0, 0, 0)
@@ -33,7 +33,7 @@ object Caret {
   implicit val caretOrder: Order[Caret] =
     new Order[Caret] {
       def compare(left: Caret, right: Caret): Int = {
-        val c0 = Integer.compare(left.row, right.row)
+        val c0 = Integer.compare(left.line, right.line)
         if (c0 != 0) c0
         else {
           val c1 = Integer.compare(left.col, right.col)

--- a/core/shared/src/main/scala/cats/parse/LocationMap.scala
+++ b/core/shared/src/main/scala/cats/parse/LocationMap.scala
@@ -69,8 +69,8 @@ class LocationMap(val input: String) {
     */
   def toLineCol(offset: Int): Option[(Int, Int)] =
     if (isValidOffset(offset)) {
-      val Caret(_, row, col) = toCaretUnsafeImpl(offset)
-      Some((row, col))
+      val Caret(_, line, col) = toCaretUnsafeImpl(offset)
+      Some((line, col))
     } else None
 
   // This does not do bounds checking because we
@@ -94,20 +94,18 @@ class LocationMap(val input: String) {
         // the key, or a.length if all elements in the array are less than the specified key.
         //
         // so insertion pos = ~(idx + 1)
-        val row = ~(idx + 1)
-        // so we are pointing into a row
-        val rowStart = firstPos(row)
-        val col = offset - rowStart
-        Caret(offset, row, col)
+        val line = ~(idx + 1)
+        // so we are pointing into a line
+        val lineStart = firstPos(line)
+        val col = offset - lineStart
+        Caret(offset, line, col)
       } else {
         // idx is exactly the right value because offset is beginning of a line
         Caret(offset, idx, 0)
       }
     }
 
-  /** Convert an offset to a Caret.
-    * @throws IllegalArgumentException
-    *   if offset is longer than input
+  /** Convert an offset to a Caret. throws IllegalArgumentException if offset is longer than input
     */
   def toCaretUnsafe(offset: Int): Caret =
     if (isValidOffset(offset)) toCaretUnsafeImpl(offset)
@@ -123,7 +121,7 @@ class LocationMap(val input: String) {
     if (i >= 0 && i < lines.length) Some(lines(i))
     else None
 
-  /** Return the offset for a given row/col. if we return Some(input.length) this means EOF if we
+  /** Return the offset for a given line/col. if we return Some(input.length) this means EOF if we
     * return Some(i) for 0 <= i < input.length it is a valid item else offset < 0 or offset >
     * input.length we return None
     */

--- a/core/shared/src/test/scala/cats/parse/ParserTest.scala
+++ b/core/shared/src/test/scala/cats/parse/ParserTest.scala
@@ -72,7 +72,7 @@ object ParserGen {
 
   implicit val cogenCaret: Cogen[Caret] =
     Cogen { caret: Caret =>
-      (caret.offset.toLong << 32) | (caret.col.toLong << 16) | (caret.row.toLong)
+      (caret.offset.toLong << 32) | (caret.col.toLong << 16) | (caret.line.toLong)
     }
 
   def arbGen[A: Arbitrary: Cogen]: GenT[Gen] =


### PR DESCRIPTION
I realized we used `line` instead of `row` in the `LocationMap` and we had a doc error that caused `v0.3.5` publish to fail, so I figured I could fix that.

