### PR TITLE
Bump Readme versions and add some tests

### DIFF
--- a/core/shared/src/main/scala/cats/parse/Caret.scala
+++ b/core/shared/src/main/scala/cats/parse/Caret.scala
@@ -30,6 +30,9 @@ case class Caret(line: Int, col: Int, offset: Int)
 object Caret {
   val Start: Caret = Caret(0, 0, 0)
 
+  /** This order is the same as offset order if the Carets are both from the same input string, but
+    * if from different ones will compare by line then by column and finally by offset.
+    */
   implicit val caretOrder: Order[Caret] =
     new Order[Caret] {
       def compare(left: Caret, right: Caret): Int = {

--- a/core/shared/src/test/scala/cats/parse/BitSetTest.scala
+++ b/core/shared/src/test/scala/cats/parse/BitSetTest.scala
@@ -25,7 +25,7 @@ import org.scalacheck.Prop.forAll
 
 class BitSetTest extends munit.ScalaCheckSuite {
   test("isScalaJs/isScalaJvm is consistent") {
-    // This will need to be updated is we ever add scala-native
+    // This will need to be updated if we ever add scala-native
     assert(!(BitSetUtil.isScalaJs && BitSetUtil.isScalaJvm))
     assert(BitSetUtil.isScalaJs || BitSetUtil.isScalaJvm)
     assert(BitSetUtil.isScalaJs ^ BitSetUtil.isScalaJvm)

--- a/core/shared/src/test/scala/cats/parse/BitSetTest.scala
+++ b/core/shared/src/test/scala/cats/parse/BitSetTest.scala
@@ -24,6 +24,13 @@ package cats.parse
 import org.scalacheck.Prop.forAll
 
 class BitSetTest extends munit.ScalaCheckSuite {
+  test("isScalaJs/isScalaJvm is consistent") {
+    // This will need to be updated is we ever add scala-native
+    assert(!(BitSetUtil.isScalaJs && BitSetUtil.isScalaJvm))
+    assert(BitSetUtil.isScalaJs || BitSetUtil.isScalaJvm)
+    assert(BitSetUtil.isScalaJs ^ BitSetUtil.isScalaJvm)
+  }
+
   property("BitSetUtil union works") {
     forAll { (cs: List[List[Char]]) =>
       val arys = cs.iterator.filter(_.nonEmpty).map(_.toArray.sorted)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,13 +8,13 @@ To use in sbt add, the following to your `libraryDependencies`:
 
 ```scala
 // use this snippet for the JVM
-libraryDependencies += "org.typelevel" %% "cats-parse" % "0.3.5"
+libraryDependencies += "org.typelevel" %% "cats-parse" % "0.3.6"
 
 // use this snippet for JS, or cross-building
-libraryDependencies += "org.typelevel" %%% "cats-parse" % "0.3.5"
+libraryDependencies += "org.typelevel" %%% "cats-parse" % "0.3.6"
 ```
 
-The [API docs](https://oss.sonatype.org/service/local/repositories/releases/archive/org/typelevel/cats-parse_2.13/0.3.5/cats-parse_2.13-0.3.5-javadoc.jar/!/cats/parse/index.html) are published.
+The [API docs](https://oss.sonatype.org/service/local/repositories/releases/archive/org/typelevel/cats-parse_2.13/0.3.6/cats-parse_2.13-0.3.6-javadoc.jar/!/cats/parse/index.html) are published.
 
 Why another parsing library? See this [blog post detailing the
 design](https://posco.medium.com/designing-a-parsing-library-in-scala-d5076de52536). To reiterate,


### PR DESCRIPTION
Does a few things:

1. bump the version mentioned in the readme
2. increase the number of test runs for LocationMapTest (which still doesn't it make it run more than a couple of seconds)
3. add a test that the pattern match on Caret is a certain order (the same order as comparison)
4. explain in a comment why the comparison order is what it is (in case we are comparing Carets from two different strings).