### PR TITLE
Tests to clarify Parser/Parser0 distinction when using string interpolator

### DIFF
--- a/core/shared/src/test/scala/cats/parse/StringInterpolatorTest.scala
+++ b/core/shared/src/test/scala/cats/parse/StringInterpolatorTest.scala
@@ -108,6 +108,9 @@ class StringInterpolatorTest extends munit.ScalaCheckSuite {
     assertEquals((parser"$p0": Parser0[Unit]).parseAll(""), Right(()))
     assertEquals((parser"foo$p0": Parser[Unit]).parseAll("foo"), Right(()))
     assertEquals((parser"$p0$p0": Parser0[(Unit, Unit)]).parseAll(""), Right(((), ())))
+    // fails in scala 3 only due to our dodgy "type inference"
+    assertEquals((parser"a${p0}b${p0}": Parser[(Unit, Unit)]).parseAll("ab"), Right(((), ())))
+    // fails in scala 2/3 due to fundamental problem of using `tupleN`
     assertEquals((parser"$p0$p": Parser[(Unit, Unit)]).parseAll("foo"), Right(((), ())))
   }
 

--- a/core/shared/src/test/scala/cats/parse/StringInterpolatorTest.scala
+++ b/core/shared/src/test/scala/cats/parse/StringInterpolatorTest.scala
@@ -99,4 +99,16 @@ class StringInterpolatorTest extends munit.ScalaCheckSuite {
     assert(compileErrors("""{ val i = 42; parser"hello $i" }""").nonEmpty)
   }
 
+  test("Parser vs Parser0") {
+    val p: Parser[Unit] = Parser.string("foo")
+    val p0: Parser0[Unit] = Parser.unit
+
+    assertEquals((parser"": Parser0[Unit]).parseAll(""), Right(()))
+    assertEquals((parser"$p": Parser[Unit]).parseAll("foo"), Right(()))
+    assertEquals((parser"$p0": Parser0[Unit]).parseAll(""), Right(()))
+    assertEquals((parser"foo$p0": Parser[Unit]).parseAll("foo"), Right(()))
+    assertEquals((parser"$p0$p0": Parser0[(Unit, Unit)]).parseAll(""), Right(((), ())))
+    assertEquals((parser"$p0$p": Parser[(Unit, Unit)]).parseAll("foo"), Right(((), ())))
+  }
+
 }


### PR DESCRIPTION
These new tests identify two problems:

* Interpolation of both a `Parser0` and `Parser` without any string parts should still expand to a `Parser`. However, using `tupleN` to combine our parsers won't work as a strategy because it finds the LUB of every component which ends up being `Parser0`. This is consistent across Scala2 and Scala 3
* Interpolation of a `Parser0` preceded by a string part should expand to a `Parser`, but doesn't in Scala 3. This is an artifact of the janky home-grown "type inference" I wrote. We should mark a sub-parser as still being a `Parser` when it has a preceding string part because it'll get turned into one when we do `{lit} *> p` anyways