### PR TITLE
Make as(()) work like void

### DIFF
--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -1718,30 +1718,34 @@ object Parser {
   def as0[B](pa: Parser0[Any], b: B): Parser0[B] =
     pa.void match {
       case p1: Parser[_] => as(p1, b)
-      case _ =>
-        Impl.unmap0(pa) match {
-          case Impl.Pure(_) | Impl.Index | Impl.GetCaret => pure(b)
-          case notPure =>
-            Impl.Void0(notPure).map(Impl.ConstFn(b))
-        }
+      case v =>
+        // If b is (), such as foo.as(())
+        // we can just return v
+        if (b == ()) v.asInstanceOf[Parser0[B]]
+        else v.map(Impl.ConstFn(b))
     }
 
   /** Replaces parsed values with the given value.
     */
   def as[B](pa: Parser[Any], b: B): Parser[B] = {
-    pa.void match {
-      case Impl.Void(ci @ Impl.CharIn(min, bs, _)) =>
-        // CharIn is common and cheap, no need to wrap
-        // with Void since CharIn always returns the char
-        // even when voided
-        b match {
-          case bc: Char if BitSetUtil.isSingleton(bs) && (min.toChar == bc) =>
-            ci.asInstanceOf[Parser[B]]
-          case _ =>
-            Impl.Map(ci, Impl.ConstFn(b))
-        }
-      case notSingleChar => notSingleChar.map(Impl.ConstFn(b))
-    }
+    val v = pa.void
+    // If b is (), such as foo.as(())
+    // we can just return v
+    if (b == ()) v.asInstanceOf[Parser[B]]
+    else
+      v match {
+        case Impl.Void(ci @ Impl.CharIn(min, bs, _)) =>
+          // CharIn is common and cheap, no need to wrap
+          // with Void since CharIn always returns the char
+          // even when voided
+          b match {
+            case bc: Char if BitSetUtil.isSingleton(bs) && (min.toChar == bc) =>
+              ci.asInstanceOf[Parser[B]]
+            case _ =>
+              Impl.Map(ci, Impl.ConstFn(b))
+          }
+        case notSingleChar => notSingleChar.map(Impl.ConstFn(b))
+      }
   }
 
   /** Add a context string to Errors to aid debugging

--- a/core/shared/src/test/scala/cats/parse/ParserTest.scala
+++ b/core/shared/src/test/scala/cats/parse/ParserTest.scala
@@ -2494,4 +2494,13 @@ class ParserTest extends munit.ScalaCheckSuite {
       assertEquals(left, right)
     }
   }
+
+  property("foo.as(()) == foo.void") {
+    forAll(ParserGen.gen) { p =>
+      assertEquals(p.fa.void, p.fa.as(()))
+    } &&
+    forAll(ParserGen.gen0) { p =>
+      assertEquals(p.fa.void, p.fa.as(()))
+    }
+  }
 }


### PR DESCRIPTION
People sometimes write `.as(())` and this makes sure that is exactly the same as `.void`.
