### PR TITLE
Improve RadixNode add a few more benchmarks

### DIFF
--- a/bench/src/main/scala/cats/parse/bench/StringInBench.scala
+++ b/bench/src/main/scala/cats/parse/bench/StringInBench.scala
@@ -48,14 +48,13 @@ class StringInBenchmarks {
     if (test == "foo") {
       inputs = List("foofoo", "bar", "foobat", "foot", "foobar")
       stringsToMatch = List("foobar", "foofoo", "foobaz", "foo", "bar")
-    }
-    else if (test == "broad") {
+    } else if (test == "broad") {
       // test all lower ascii strings like aaaa, aaab, aaac, ... bbba, bbbb, bbbc, ...
       stringsToMatch = (for {
         h <- 'a' to 'z'
         t <- 'a' to 'z'
       } yield s"$h$h$h$t").toList
-      
+
       // take 10% of the inputs
       inputs = stringsToMatch.filter(_.hashCode % 10 == 0)
     }

--- a/bench/src/main/scala/cats/parse/bench/StringInBench.scala
+++ b/bench/src/main/scala/cats/parse/bench/StringInBench.scala
@@ -33,9 +33,9 @@ class StringInBenchmarks {
   val inputs =
     List("foofoo", "bar", "foobat", "foot", "foobar")
 
-  val stringsToMatch =     
+  val stringsToMatch =
     "foobar" :: "foofoo" :: "foobaz" :: "foo" :: "bar" :: Nil
-  
+
   val radixNode = RadixNode.fromStrings(stringsToMatch)
 
   val stringIn = Parser.stringIn(stringsToMatch)
@@ -45,7 +45,6 @@ class StringInBenchmarks {
       stringsToMatch.map { s => Parser.string(s) }
     )
 
-    /*
   @Benchmark
   def stringInParse(): Unit =
     inputs.foreach(stringIn.parseAll(_))
@@ -53,7 +52,6 @@ class StringInBenchmarks {
   @Benchmark
   def oneOfParse(): Unit =
     inputs.foreach(oneOf.parseAll(_))
-    */
 
   @Benchmark
   def radixMatchIn(): Unit =

--- a/bench/src/main/scala/cats/parse/bench/StringInBench.scala
+++ b/bench/src/main/scala/cats/parse/bench/StringInBench.scala
@@ -29,7 +29,7 @@ import org.openjdk.jmh.annotations._
 @State(Scope.Benchmark)
 @BenchmarkMode(Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-class StringInBenchmarks {
+private[parse] class StringInBenchmarks {
   @Param(Array("foo", "broad"))
   var test: String = _
 

--- a/bench/src/main/scala/cats/parse/bench/StringInBench.scala
+++ b/bench/src/main/scala/cats/parse/bench/StringInBench.scala
@@ -19,7 +19,8 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package cats.parse.bench
+package cats.parse
+package bench
 
 import cats.parse.Parser
 import java.util.concurrent.TimeUnit
@@ -32,18 +33,19 @@ class StringInBenchmarks {
   val inputs =
     List("foofoo", "bar", "foobat", "foot", "foobar")
 
-  val stringIn = Parser.stringIn("foo" :: "bar" :: "foobar" :: "foofoo" :: "foobaz" :: Nil)
+  val stringsToMatch =     
+    "foobar" :: "foofoo" :: "foobaz" :: "foo" :: "bar" :: Nil
+  
+  val radixNode = RadixNode.fromStrings(stringsToMatch)
+
+  val stringIn = Parser.stringIn(stringsToMatch)
 
   val oneOf =
     Parser.oneOf(
-      Parser.string("foobar") ::
-        Parser.string("foobaz") ::
-        Parser.string("foofoo") ::
-        Parser.string("foo") ::
-        Parser.string("bar") ::
-        Nil
+      stringsToMatch.map { s => Parser.string(s) }
     )
 
+    /*
   @Benchmark
   def stringInParse(): Unit =
     inputs.foreach(stringIn.parseAll(_))
@@ -51,5 +53,13 @@ class StringInBenchmarks {
   @Benchmark
   def oneOfParse(): Unit =
     inputs.foreach(oneOf.parseAll(_))
+    */
 
+  @Benchmark
+  def radixMatchIn(): Unit =
+    inputs.foreach { s => radixNode.matchAt(s, 0) >= 0 }
+
+  @Benchmark
+  def linearMatchIn(): Unit =
+    inputs.foreach { s => stringsToMatch.exists(s.startsWith(_)) }
 }

--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -1536,7 +1536,7 @@ object Parser {
     if (cs.isEmpty) fail
     else {
       val ary = cs.toArray
-      java.util.Arrays.sort(ary)
+      Arrays.sort(ary)
       rangesFor(ary) match {
         case NonEmptyList((low, high), Nil) if low == Char.MinValue && high == Char.MaxValue =>
           anyChar
@@ -2444,33 +2444,9 @@ object Parser {
 
     final def stringIn[A](radix: RadixNode, all: SortedSet[String], state: State): Unit = {
       val str = state.str
-      val strLength = str.length
       val startOffset = state.offset
+      val lastMatch = radix.matchAt(str, startOffset)
 
-      var offset = startOffset
-      var tree = radix
-      var cont = offset < strLength
-      var lastMatch = -1
-
-      while (cont) {
-        val c = str.charAt(offset)
-        val idx = Arrays.binarySearch(tree.fsts, c)
-        if (idx >= 0) {
-          val prefix = tree.prefixes(idx)
-          // accept the prefix fo this character
-          if (str.startsWith(prefix, offset + 1)) {
-            val children = tree.children(idx)
-            offset += (prefix.length + 1)
-            tree = children
-            cont = offset < strLength
-            if (children.word) lastMatch = offset
-          } else {
-            cont = false
-          }
-        } else {
-          cont = false
-        }
-      }
       if (lastMatch < 0) {
         state.error = Eval.later(Chain.one(Expectation.OneOfStr(startOffset, all.toList)))
         state.offset = startOffset

--- a/core/shared/src/main/scala/cats/parse/RadixNode.scala
+++ b/core/shared/src/main/scala/cats/parse/RadixNode.scala
@@ -25,8 +25,6 @@ import cats.data.NonEmptyList
 import cats.kernel.Semilattice
 import scala.annotation.tailrec
 
-import cats.syntax.all._
-
 private[parse] final class RadixNode(
     matched: String,
     bitMask: Int,
@@ -114,10 +112,10 @@ private[parse] object RadixNode {
       val branching = bitMask + 1
       val prefixes = new Array[String](branching)
       val children = new Array[RadixNode](branching)
-      val tree = nonEmpties.groupByNel { s => (s.head.toInt & bitMask) }
+      val tree = nonEmpties.groupBy { s => (s.head.toInt & bitMask) }
       tree.foreach { case (idx, strings) =>
         // strings is a NonEmptyList[String] which all start with the same char
-        val prefix1 = strings.reduce(commonPrefixSemilattice)
+        val prefix1 = strings.reduce(commonPrefixSemilattice.combine(_, _))
         val plen = prefix1.length
         val node = fromTree(thisPrefix, prefix + prefix1, strings.map(_.drop(plen)).toList)
         prefixes(idx) = prefix1
@@ -129,7 +127,7 @@ private[parse] object RadixNode {
   }
 
   def fromSortedStrings(strings: NonEmptyList[String]): RadixNode =
-    fromTree(null, "", strings.distinct.toList)
+    fromTree(null, "", strings.toList.distinct)
 
   def fromStrings(strs: Iterable[String]): RadixNode =
     fromTree(null, "", strs.toList.distinct)

--- a/core/shared/src/main/scala/cats/parse/RadixNode.scala
+++ b/core/shared/src/main/scala/cats/parse/RadixNode.scala
@@ -28,11 +28,11 @@ import scala.annotation.tailrec
 import cats.syntax.all._
 
 private[parse] final class RadixNode(
-    protected val matched: String,
-    protected val bitMask: Int,
+    matched: String,
+    bitMask: Int,
     // the prefixes are the rest of the string after the fsts (not including the fsts Char)
-    protected val prefixes: Array[String],
-    protected val children: Array[RadixNode]
+    prefixes: Array[String],
+    children: Array[RadixNode]
 ) {
   override def toString(): String = {
     def list[A](ary: Array[A]): String = ary.mkString("[", ", ", "]")
@@ -56,25 +56,33 @@ private[parse] final class RadixNode(
       case nonNull => nonNull.length
     }
 
-  @tailrec
   final def matchAtOrNull(str: String, offset: Int): String =
-    if (offset < str.length)  {
+    if (offset < 0) null
+    else matchAtOrNullLoop(str, offset)
+
+  // loop invariant: 0 <= offset
+  @tailrec
+  final protected def matchAtOrNullLoop(str: String, offset: Int): String =
+    if (offset < str.length) {
       val c = str.charAt(offset)
       // this is a hash of c
       val idx = c.toInt & bitMask
       val prefix = prefixes(idx)
       if (prefix ne null) {
         // accept the prefix fo this character
-        if (str.regionMatches(offset, prefix, 0, prefix.length)) {
-          children(idx).matchAtOrNull(str, offset + prefix.length)
+        val plen = prefix.length
+        if (str.regionMatches(offset, prefix, 0, plen)) {
+          children(idx).matchAtOrNullLoop(str, offset + plen)
         } else {
           matched
         }
       } else {
         matched
       }
-    }
-    else {
+    } else if (offset > str.length) {
+      null
+    } else {
+      // this is only the case where offset == str.length
       matched
     }
 }
@@ -83,56 +91,55 @@ private[parse] object RadixNode {
   private val emptyStringArray = new Array[String](1)
   private val emptyChildrenArray = new Array[RadixNode](1)
 
-  private def fromNonEmpty(prefix: String, nonEmpty: NonEmptyList[String]): RadixNode = {
-    val nonEmpties = nonEmpty.toList.filter(_.nonEmpty)
+  private def fromTree(prefix: String, rest: List[String]): RadixNode = {
+    val nonEmpties = rest.toList.filter(_.nonEmpty)
     val headKeys = nonEmpties.iterator.map(_.head).toSet
 
-    @tailrec
-    def findBitMask(b: Int): Int =
-      if (b == 0xffff) b // biggest it can be
-      else {
-        val allDistinct = headKeys.iterator.map { c => c.toInt & b }.toSet.size == headKeys.size
-        if (allDistinct) b
-        else findBitMask((b << 1) | 1)
+    // If nonEmpty contains the empty string, we have a valid prefix
+    val thisPrefix = if (rest.exists(_.isEmpty)) prefix else null
+
+    if (nonEmpties.isEmpty) {
+      new RadixNode(thisPrefix, 0, emptyStringArray, emptyChildrenArray)
+    } else {
+      @tailrec
+      def findBitMask(b: Int): Int =
+        if (b == 0xffff) b // biggest it can be
+        else {
+          val allDistinct = headKeys.iterator.map { c => c.toInt & b }.toSet.size == headKeys.size
+          if (allDistinct) b
+          else findBitMask((b << 1) | 1)
+        }
+
+      val bitMask = findBitMask(0)
+      val branching = bitMask + 1
+      val prefixes = new Array[String](branching)
+      val children = new Array[RadixNode](branching)
+      val tree = nonEmpties.groupByNel { s => (s.head.toInt & bitMask) }
+      tree.foreach { case (idx, strings) =>
+        // strings is a NonEmptyList[String] which all start with the same char
+        val prefix1 = strings.reduce(commonPrefixSemilattice)
+        val plen = prefix1.length
+        val node = fromTree(prefix + prefix1, strings.map(_.drop(plen)).toList)
+        prefixes(idx) = prefix1
+        children(idx) = node
       }
 
-    val bitMask = findBitMask((1 << Integer.highestOneBit(headKeys.size)) - 1)
-    val branching = bitMask + 1
-    val prefixes = new Array[String](branching)
-    val children = new Array[RadixNode](branching)
-    val tree = nonEmpties.groupByNel { s => (s.head.toInt & bitMask) }
-    tree.foreach { case (idx, strings) =>
-      // strings is a NonEmptyList[String] which all start with the same char
-      val prefix1 = strings.reduce(commonPrefixSemilattice)
-      val plen = prefix1.length
-      val node = fromNonEmpty(prefix + prefix1, strings.map(_.drop(plen)))
-      prefixes(idx) = prefix1
-      children(idx) = node
+      new RadixNode(thisPrefix, bitMask, prefixes, children)
     }
-
-    // If nonEmpty contains the empty string, we have a valid prefix
-    val thisPrefix = if (nonEmpty.exists(_.isEmpty)) prefix else null
-    new RadixNode(thisPrefix, bitMask, prefixes, children)
   }
 
   def fromSortedStrings(strings: NonEmptyList[String]): RadixNode =
-    fromNonEmpty("", strings)
+    fromTree("", strings.distinct.toList)
 
   def fromStrings(strs: Iterable[String]): RadixNode =
-    NonEmptyList.fromList(strs.toList.distinct) match {
-      case Some(nel) => fromSortedStrings(nel)
-      case None => empty
-    }
-
-  private val empty = new RadixNode(null, 0, emptyStringArray, emptyChildrenArray)
+    fromTree("", strs.toList.distinct)
 
   final def commonPrefixLength(s1: String, s2: String): Int = {
     val len = Integer.min(s1.length, s2.length)
     var idx = 0
-    var cont = true
-    while (cont) {
-      if ((idx >= len) || (s1.charAt(idx) != s2.charAt(idx))) {
-        cont = false
+    while (idx < len) {
+      if (s1.charAt(idx) != s2.charAt(idx)) {
+        return idx
       } else {
         idx = idx + 1
       }

--- a/core/shared/src/main/scala/cats/parse/RadixNode.scala
+++ b/core/shared/src/main/scala/cats/parse/RadixNode.scala
@@ -91,12 +91,12 @@ private[parse] object RadixNode {
   private val emptyStringArray = new Array[String](1)
   private val emptyChildrenArray = new Array[RadixNode](1)
 
-  private def fromTree(prefix: String, rest: List[String]): RadixNode = {
+  private def fromTree(prevMatch: String, prefix: String, rest: List[String]): RadixNode = {
     val nonEmpties = rest.toList.filter(_.nonEmpty)
     val headKeys = nonEmpties.iterator.map(_.head).toSet
 
     // If nonEmpty contains the empty string, we have a valid prefix
-    val thisPrefix = if (rest.exists(_.isEmpty)) prefix else null
+    val thisPrefix = if (rest.exists(_.isEmpty)) prefix else prevMatch
 
     if (nonEmpties.isEmpty) {
       new RadixNode(thisPrefix, 0, emptyStringArray, emptyChildrenArray)
@@ -119,7 +119,7 @@ private[parse] object RadixNode {
         // strings is a NonEmptyList[String] which all start with the same char
         val prefix1 = strings.reduce(commonPrefixSemilattice)
         val plen = prefix1.length
-        val node = fromTree(prefix + prefix1, strings.map(_.drop(plen)).toList)
+        val node = fromTree(thisPrefix, prefix + prefix1, strings.map(_.drop(plen)).toList)
         prefixes(idx) = prefix1
         children(idx) = node
       }
@@ -129,10 +129,10 @@ private[parse] object RadixNode {
   }
 
   def fromSortedStrings(strings: NonEmptyList[String]): RadixNode =
-    fromTree("", strings.distinct.toList)
+    fromTree(null, "", strings.distinct.toList)
 
   def fromStrings(strs: Iterable[String]): RadixNode =
-    fromTree("", strs.toList.distinct)
+    fromTree(null, "", strs.toList.distinct)
 
   final def commonPrefixLength(s1: String, s2: String): Int = {
     val len = Integer.min(s1.length, s2.length)

--- a/core/shared/src/test/scala/cats/parse/RadixNodeTest.scala
+++ b/core/shared/src/test/scala/cats/parse/RadixNodeTest.scala
@@ -139,9 +139,9 @@ class RadixNodeTest extends munit.ScalaCheckSuite {
   }
 
   property("RadixTree singleton") {
-    forAll { (s: String, prefix: String) =>
+    forAll { (s: String, prefix: String, suffix: String) =>
       val tree = RadixNode.fromStrings(s :: Nil)
-      assertEquals(tree.matchAtOrNull(prefix + s, prefix.length), s)
+      assertEquals(tree.matchAtOrNull(prefix + s + suffix, prefix.length), s)
     }
   }
 
@@ -174,4 +174,8 @@ class RadixNodeTest extends munit.ScalaCheckSuite {
     }
   }
 
+  test("example from ParserTest") {
+    val tree = RadixNode.fromStrings(List("foo", "foobar", "foofoo", "foobat"))
+    assertEquals(tree.matchAtOrNull("foobal", 0), "foo")
+  }
 }

--- a/core/shared/src/test/scala/cats/parse/RadixNodeTest.scala
+++ b/core/shared/src/test/scala/cats/parse/RadixNodeTest.scala
@@ -21,9 +21,17 @@
 
 package cats.parse
 
+import org.scalacheck.Prop
 import org.scalacheck.Prop.forAll
 
 class RadixNodeTest extends munit.ScalaCheckSuite {
+  val tests: Int = if (BitSetUtil.isScalaJs) 50 else 20000
+
+  override def scalaCheckTestParameters =
+    super.scalaCheckTestParameters
+      .withMinSuccessfulTests(tests)
+      .withMaxDiscardRatio(10)
+
   property("commonPrefixLength is consistent") {
     forAll { (s1: String, s2: String) =>
       val len = RadixNode.commonPrefixLength(s1, s2)
@@ -33,6 +41,12 @@ class RadixNodeTest extends munit.ScalaCheckSuite {
       assert(len <= minLen)
       assertEquals(s1.take(len), s2.take(len))
       if (len < minLen) assertNotEquals(s1.charAt(len), s2.charAt(len))
+    }
+  }
+
+  property("commonPrefixLength is commutative") {
+    forAll { (s1: String, s2: String) =>
+      assertEquals(RadixNode.commonPrefixLength(s1, s2), RadixNode.commonPrefixLength(s2, s1))
     }
   }
 
@@ -51,6 +65,36 @@ class RadixNodeTest extends munit.ScalaCheckSuite {
   property("commonPrefixLength is commutative") {
     forAll { (s: String, r: String) =>
       assertEquals(RadixNode.commonPrefixLength(s, r), RadixNode.commonPrefixLength(r, s))
+    }
+  }
+
+  property("If we match, then string is in the set") {
+    def law(ss0: List[String], target: String): Prop = {
+      val ss = ss0.filter(_.nonEmpty)
+      val radix = RadixNode.fromStrings(ss)
+      assertEquals(radix.matchAt(target, 0) >= 0, ss.exists(target.startsWith(_)))
+    }
+
+    val p1 = forAll { (ss: List[String], head: Char, tail: String) =>
+      val target = s"$head$tail"
+      law(ss, target)
+    }
+
+    val regressions =
+      (List("噈"), s"噈\u0000") ::
+        Nil
+
+    regressions.foldLeft(p1) { case (p, (ss, t)) => p && law(ss, t) }
+  }
+
+  property("If we match everything in the set") {
+    forAll { (ss0: List[String], head: Char, tail: String) =>
+      val s1 = s"$head$tail"
+      val ss = s1 :: ss0
+      val radix = RadixNode.fromStrings(ss)
+      ss.foreach { target =>
+        assert((radix.matchAt(target, 0) >= 0) || target.isEmpty)
+      }
     }
   }
 }

--- a/core/shared/src/test/scala/cats/parse/RadixNodeTest.scala
+++ b/core/shared/src/test/scala/cats/parse/RadixNodeTest.scala
@@ -178,4 +178,10 @@ class RadixNodeTest extends munit.ScalaCheckSuite {
     val tree = RadixNode.fromStrings(List("foo", "foobar", "foofoo", "foobat"))
     assertEquals(tree.matchAtOrNull("foobal", 0), "foo")
   }
+
+  property("RadixNode.allStrings roundTrips") {
+    forAll { (ss: List[String]) =>
+      assertEquals(RadixNode.fromStrings(ss).allStrings.sorted, ss.distinct.sorted)
+    }
+  }
 }

--- a/core/shared/src/test/scala/cats/parse/RadixNodeTest.scala
+++ b/core/shared/src/test/scala/cats/parse/RadixNodeTest.scala
@@ -121,6 +121,14 @@ class RadixNodeTest extends munit.ScalaCheckSuite {
     }
   }
 
+  property("commonPrefix is finds prefix") {
+    val sl = RadixNode.commonPrefixSemilattice
+    forAll { (s0: String, suffix: String) =>
+      assertEquals(sl.combine(s0, s0 + suffix), s0)
+      assertEquals(sl.combine(s0 + suffix, s0), s0)
+    }
+  }
+
   property("RadixNode.fromStrings(emptyString :: Nil) matches everything") {
     val nilRadix = RadixNode.fromStrings("" :: Nil)
     forAll { (targ: String) =>


### PR DESCRIPTION
part of #350 

This may be marginally faster, but the main value it adds is that RadixNode can now return the matching string without allocating. Also, I think the implementation is somewhat simpler.

I expect this should be faster if the set of strings gets larger (the benchmarks only have a few different prefixes. This uses a hash based approach so it is always O(1) to check a character (not log(N) worst case).

```
Before:

[info] Benchmark                         Mode  Cnt   Score   Error  Units
[info] StringInBenchmarks.linearMatchIn  avgt    3  77.603 ± 0.529  ns/op
[info] StringInBenchmarks.radixMatchIn   avgt    3  59.675 ± 2.126  ns/op

This PR:

[info] Benchmark                         Mode  Cnt   Score   Error  Units
[info] StringInBenchmarks.linearMatchIn  avgt    3  77.427 ± 4.083  ns/op
[info] StringInBenchmarks.radixMatchIn   avgt    3  59.067 ± 4.797  ns/op
```