### PR TITLE
Optimize Not error condition

### DIFF
--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -2934,10 +2934,17 @@ object Parser {
           state.error = null
         } else {
           // under succeeded but we expected failure here
-          val matchedStr = state.str.substring(offset, state.offset)
+          // record the current offset before it changes
+          // in a potential operation
+          val offsetErr = state.offset
           // we don't reset the offset, so if the underlying parser
           // advanced it will fail in a OneOf
-          state.error = Eval.later(Chain.one(Expectation.ExpectedFailureAt(offset, matchedStr)))
+          state.error = Eval.later {
+            // put as much as possible here, but cannot reference
+            // mutable vars
+            val matchedStr = state.str.substring(offset, offsetErr)
+            Chain.one(Expectation.ExpectedFailureAt(offset, matchedStr))
+          }
         }
 
         state.offset = offset


### PR DESCRIPTION
We use `Eval` to defer doing any work except allocation on errors since `oneOf` can recover failures. So we don't actually want to run the error condition until the end.

`Not` was allocating a copy of a string before the `Eval` so that allocation had to happen on every failure, which could be a lot for some cases. By moving the allocation inside the Eval we will (almost certainly) save.