### PR TITLE
Improve String generation

### DIFF
--- a/core/shared/src/main/scala/cats/parse/Numbers.scala
+++ b/core/shared/src/main/scala/cats/parse/Numbers.scala
@@ -30,11 +30,11 @@ object Numbers {
 
   /** zero or more digit chars
     */
-  val digits0: Parser0[String] = digit.rep0.string
+  val digits0: Parser0[String] = digit.repAs0
 
   /** one or more digit chars
     */
-  val digits: Parser[String] = digit.rep.string
+  val digits: Parser[String] = digit.repAs
 
   /** a single base 10 digit excluding 0
     */


### PR DESCRIPTION
Previously we were using scalacheck `Arbitrary.arbitrary[String]` which generates strings from a huge space. The problem is that the chance you randomly generate anything that will parse will be very low.

Here we improve is somewhat by choosing strings from three spaces: `('a', 'A', 'b', 'B', ' ')`, printable ascii, and all unicode.

The idea is that some laws that might not fail for all unicode (because we just generate parsers and strings that never match) might fail if we restrict the string space enough.

No tests failed, but still I think it is better.
