### PR TITLE
Allow Scala 3 update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [3.0.2, 2.11.12, 2.12.15, 2.13.8]
+        scala: [3.1.2, 2.11.12, 2.12.15, 2.13.8]
         java: [temurin@8]
     runs-on: ${{ matrix.os }}
     steps:
@@ -133,12 +133,12 @@ jobs:
             ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
-      - name: Download target directories (3.0.2)
+      - name: Download target directories (3.1.2)
         uses: actions/download-artifact@v2
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-3.0.2
+          name: target-${{ matrix.os }}-${{ matrix.java }}-3.1.2
 
-      - name: Inflate target directories (3.0.2)
+      - name: Inflate target directories (3.1.2)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ ThisBuild / tlBaseVersion := "0.3"
 ThisBuild / startYear := Some(2021)
 ThisBuild / developers += tlGitHubDev("johnynek", "P. Oscar Boykin")
 
-ThisBuild / crossScalaVersions := List("3.0.2", "2.11.12", "2.12.15", "2.13.8")
+ThisBuild / crossScalaVersions := List("3.1.2", "2.11.12", "2.12.15", "2.13.8")
 ThisBuild / tlVersionIntroduced := Map("3" -> "0.3.4")
 
 ThisBuild / githubWorkflowBuild := Seq(
@@ -74,6 +74,15 @@ lazy val jvmVersionSettings = VersionNumber(sys.props("java.version")) match {
   case _ => Def.settings()
 }
 
+lazy val publishSettings = Def.settings {
+  scalaOutputVersion := {
+    CrossVersion.partialVersion((scalaVersion).value) match {
+      case Some((3, _)) => "3.0.2"
+      case _ => scalaVersion.value
+    }
+  }
+}
+
 lazy val root = project
   .in(file("."))
   .aggregate(core.jvm, core.js, bench)
@@ -110,6 +119,7 @@ lazy val docs = project
 
 lazy val core = crossProject(JSPlatform, JVMPlatform)
   .crossType(CrossType.Full)
+  .settings(publishSettings)
   .settings(
     name := "cats-parse",
     tlFatalWarningsInCi := !tlIsScala3.value,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.7.0-M2


### PR DESCRIPTION
This is merely an evaluation of the new setting coming up in sbt 1.7.0 and the new compiler flag in scala 3.1.2 that allows setting the output target.

@johnynek Since this relies on a milestone version not sure if you wanna go for it.

Fixes #285 
Closes #408 

