### PR TITLE
Only publish site on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,7 +275,6 @@ jobs:
 
   publish-site:
     name: Publish site
-    needs: [publish]
     if: github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/v')
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,14 +187,6 @@ jobs:
       - name: Publish
         run: sbt '++${{ matrix.scala }}' tlRelease
 
-      - run: sbt '++${{ matrix.scala }}' docs/makeSite
-
-      - uses: JamesIves/github-pages-deploy-action@3.7.1
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: docs/target/site
-
   build-docs:
     name: Build docs
     strategy:
@@ -280,3 +272,53 @@ jobs:
       - run: sbt '++${{ matrix.scala }}' coverage test coverageAggregate
 
       - run: 'bash <(curl -s https://codecov.io/bash)'
+
+  publish-site:
+    name: Publish site
+    needs: [publish]
+    if: github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/v')
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        scala: [2.13.8]
+        java: [temurin@11]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout current branch (fast)
+        uses: actions/checkout@v2
+
+      - name: Download Java (temurin@11)
+        id: download-java-temurin-11
+        if: matrix.java == 'temurin@11'
+        uses: typelevel/download-java@v1
+        with:
+          distribution: temurin
+          java-version: 11
+
+      - name: Setup Java (temurin@11)
+        if: matrix.java == 'temurin@11'
+        uses: actions/setup-java@v2
+        with:
+          distribution: jdkfile
+          java-version: 11
+          jdkFile: ${{ steps.download-java-temurin-11.outputs.jdkFile }}
+
+      - name: Cache sbt
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.sbt
+            ~/.ivy2/cache
+            ~/.coursier/cache/v1
+            ~/.cache/coursier/v1
+            ~/AppData/Local/Coursier/Cache/v1
+            ~/Library/Caches/Coursier/v1
+          key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+
+      - run: sbt '++${{ matrix.scala }}' docs/makeSite
+
+      - uses: JamesIves/github-pages-deploy-action@3.7.1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: docs/target/site


### PR DESCRIPTION
Fixing the current `main` build issue introduced with https://github.com/typelevel/cats-parse/runs/6804145548

Including a Java step here as well since parboiled, dependency from paradox, is java 11 only now.

We had this before, but we can change CI to use Java 11 by default since we are setting the targets correctly.