### PR TITLE
Test json number parsing against Jawn

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -59,7 +59,8 @@ lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
       Seq(
         if (isScala211.value) cats211.value else cats.value,
         munit.value % Test,
-        munitScalacheck.value % Test
+        munitScalacheck.value % Test,
+        (if (isScala211.value) jawnAst211.value else jawnAst.value) % Test
       )
     },
     libraryDependencies ++= {
@@ -109,7 +110,7 @@ lazy val bench = project
       Seq(
         fastParse,
         parsley,
-        jawnAst,
+        jawnAst.value,
         parboiled,
         attoCore
       ),

--- a/build.sbt
+++ b/build.sbt
@@ -59,8 +59,7 @@ lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
       Seq(
         if (isScala211.value) cats211.value else cats.value,
         munit.value % Test,
-        munitScalacheck.value % Test,
-        (if (isScala211.value) jawnAst211.value else jawnAst.value) % Test
+        munitScalacheck.value % Test
       )
     },
     libraryDependencies ++= {
@@ -87,6 +86,11 @@ lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
         )
       else Nil
     } ++ MimaExclusionRules.parserImpl ++ MimaExclusionRules.bitSetUtil
+  )
+  .jvmSettings(
+    // We test against jawn on JVM for some json parsers
+    libraryDependencies +=
+      (if (isScala211.value) jawnAst211.value else jawnAst.value) % Test
   )
   .jsSettings(
     crossScalaVersions := (ThisBuild / crossScalaVersions).value.filterNot(_.startsWith("2.11")),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,8 @@ object Dependencies {
   lazy val munitScalacheck = Def.setting("org.scalameta" %%% "munit-scalacheck" % "1.0.0-M6")
   lazy val fastParse = "com.lihaoyi" %% "fastparse" % "2.3.3"
   lazy val parsley = "org.http4s" %% "parsley" % "1.5.0-M3"
-  lazy val jawnAst = "org.typelevel" %% "jawn-ast" % "1.4.0"
+  lazy val jawnAst = Def.setting("org.typelevel" %% "jawn-ast" % "1.4.0")
+  lazy val jawnAst211 = Def.setting("org.typelevel" %% "jawn-ast" % "1.0.0-RC2")
   lazy val parboiled = "org.parboiled" %% "parboiled" % "2.4.0"
   lazy val attoCore = "org.tpolecat" %% "atto-core" % "0.9.5"
 }


### PR DESCRIPTION
The idea here is to make sure we actually agree with a json number parsing implementation such as Jawn.

We should do the same for json string parsing when that is added #433 
