### PR TITLE
Add an example on how to implement a parser for interspersed input

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -367,6 +367,31 @@ p3.parse("The Wind Has Risen")
 
 So when the _right side_ returns an epsilon failure the `soft` method allows us to rewind parsed input and try to proceed it's parsing with next parsers (without changing the parser itself!).
 
+Another common use case for `soft` is implementing a parser to find values interspersed with a separator. For example, if you want to extract `'a'`, `'b'` and `'c'` from `"a,b,c"`, you can use `soft`.
+
+Naively, one may try the following:
+
+```scala mdoc
+val p4 = alpha
+val naiveInterspersed = (p4 <* pchar(',')).rep
+naiveInterspersed.parse("a,b,c")
+// res4 = Left(Error(5,NonEmptyList(InRange(offset = 5, lower = ',', upper = ','),List())))
+```
+
+Basically, it's looking for the trailing comma:
+
+```scala mdoc
+naiveInterspersed.parse("a,b,c,")
+// res5 = Right(("", NonEmptyList('a', List('b', 'c'))))
+```
+
+But you can use, `soft` along with `|` to implement that:
+```scala mdoc
+val interspersed = ((p4.soft <* pchar(',')) | p4).rep
+interspersed.parse("a,b,c")
+// res6 = Right(("", NonEmptyList('a', List('b', 'c'))))
+```
+
 # JSON parser example
 
 Below is most of a json parser (the string unescaping is elided). This example can give you a feel


### PR DESCRIPTION
While looking at the documentation I found some things that I could be improved so here is a PR for that.

I was specifically looking to see how I could implement something to parse `"a,b,c" and extract `a`, `b` and `c`. I found that soft could be used for that and because I think it's a common pattern in parsers, I figured it could be useful to have an example in the documentation.

On top of that, I get feedback from experts to tell me if that solution is bad and what would be a better alternative, win-win!

----

One annoying thing about the `docs/index.md` is that yes, it's compiled but it's not the actual output of mdoc and so the result in there are hard coded. I found it annoying to go into `site/target/mdoc/index.md` and retrieve the output and format it to fit with the rest of the document. Is there a better way?