### PR TITLE
clean up 'recursive' parser description

### DIFF
--- a/core/shared/src/main/scala/cats/parse/Parser.scala
+++ b/core/shared/src/main/scala/cats/parse/Parser.scala
@@ -1706,8 +1706,8 @@ object Parser {
   def defer0[A](pa: => Parser0[A]): Parser0[A] =
     Impl.Defer0(() => pa)
 
-  /** Build a recursive parser by assuming you have it Useful for parsing recurive structures, like
-    * for instance JSON.
+  /** Build a recursive parser by assuming you have it Useful for parsing recursive structures like
+    * JSON.
     */
   def recursive[A](fn: Parser[A] => Parser[A]): Parser[A] = {
     lazy val result: Parser[A] = fn(defer(result))


### PR DESCRIPTION
The comment for the `recursive` parser has a spelling error and its grammar could be improved. This is a very simple pull request that addresses these things!
---
Thank you for contributing to `cats-parse`!

This is a kind reminder to run `sbt prePR` and commit the changed files, if any, before submitting.


