### PR TITLE
updates cats-parse version in libraryDependencies in README

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,10 +8,10 @@ To use in sbt add, the following to your `libraryDependencies`:
 
 ```scala
 // use this snippet for the JVM
-libraryDependencies += "org.typelevel" %% "cats-parse" % "0.3.7"
+libraryDependencies += "org.typelevel" %% "cats-parse" % "0.3.9"
 
 // use this snippet for JS, or cross-building
-libraryDependencies += "org.typelevel" %%% "cats-parse" % "0.3.7"
+libraryDependencies += "org.typelevel" %%% "cats-parse" % "0.3.9"
 ```
 
 The [API docs](https://javadoc.io/doc/org.typelevel/cats-parse_2.13/0.3.9/cats/parse/index.html) are published.


### PR DESCRIPTION
Update the README file to include the current latest cats-parse version `0.3.9` in `libraryDependencies`