### PR TITLE
Support Scala native 0.5, Update deps

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -120,7 +120,8 @@ lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   )
   .nativeSettings(
     crossScalaVersions := (ThisBuild / crossScalaVersions).value.filterNot(_.startsWith("2.11")),
-    tlVersionIntroduced := List("2.12", "2.13", "3").map(_ -> "0.3.8").toMap,
+    // cats-parse 1.0.1 switches to Scala Native 0.5, reset tlVersionIntroduced
+    tlVersionIntroduced := List("2.12", "2.13", "3").map(_ -> "1.0.1").toMap,
     coverageEnabled := false
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import com.typesafe.tools.mima.core._
 import Dependencies._
 val scala211 = "2.11.12"
 val scala212 = "2.12.19"
-val scala213 = "2.13.12"
+val scala213 = "2.13.14"
 val scala3 = "3.3.3"
 
 GlobalScope / tlCommandAliases ++= Map(

--- a/build.sbt
+++ b/build.sbt
@@ -67,11 +67,18 @@ lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(
     name := "cats-parse",
     libraryDependencies ++= {
-      Seq(
-        if (isScala211.value) cats211.value else cats.value,
-        munit.value % Test,
-        munitScalacheck.value % Test
-      )
+      if (isScala211.value)
+        Seq(
+          cats211.value,
+          munit211.value % Test,
+          munitScalacheck211.value % Test,
+        )
+      else
+        Seq(
+          cats.value,
+          munit.value % Test,
+          munitScalacheck.value % Test,
+        )
     },
     libraryDependencies ++= {
       if (tlIsScala3.value) Nil else Seq("org.scala-lang" % "scala-reflect" % scalaVersion.value)

--- a/build.sbt
+++ b/build.sbt
@@ -71,13 +71,13 @@ lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
         Seq(
           cats211.value,
           munit211.value % Test,
-          munitScalacheck211.value % Test,
+          munitScalacheck211.value % Test
         )
       else
         Seq(
           cats.value,
           munit.value % Test,
-          munitScalacheck.value % Test,
+          munitScalacheck.value % Test
         )
     },
     libraryDependencies ++= {

--- a/core/jvm/src/test/scala/cats/parse/JvmNumbersTests.scala
+++ b/core/jvm/src/test/scala/cats/parse/JvmNumbersTests.scala
@@ -41,7 +41,7 @@ class JvmNumbersTest extends munit.ScalaCheckSuite {
       case Left(_) => None
       case Right(a) => Some(a)
     }
-    val jawn = JParser.parseFromString(a).toOption.collect { case jn: JNum => jn }
+    val jawn = JParser.parseFromString(a).toOption.collect { case jnum: JNum => jnum }
 
     assertEquals(jn.isDefined, jawn.isDefined)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,8 +4,8 @@ import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 object Dependencies {
   lazy val cats = Def.setting("org.typelevel" %%% "cats-core" % "2.12.0")
   lazy val cats211 = Def.setting("org.typelevel" %%% "cats-core" % "2.0.0")
-  lazy val munit = Def.setting("org.scalameta" %%% "munit" % "1.0.0-M10")
-  lazy val munitScalacheck = Def.setting("org.scalameta" %%% "munit-scalacheck" % "1.0.0-M10")
+  lazy val munit = Def.setting("org.scalameta" %%% "munit" % "1.0.0")
+  lazy val munitScalacheck = Def.setting("org.scalameta" %%% "munit-scalacheck" % "1.0.0")
   lazy val fastParse = "com.lihaoyi" %% "fastparse" % "3.1.1"
   lazy val parsley = "org.http4s" %% "parsley" % "1.5.0-M3"
   lazy val jawnAst = Def.setting("org.typelevel" %% "jawn-ast" % "1.6.0")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 
 object Dependencies {
-  lazy val cats = Def.setting("org.typelevel" %%% "cats-core" % "2.11.0")
+  lazy val cats = Def.setting("org.typelevel" %%% "cats-core" % "2.12.0")
   lazy val cats211 = Def.setting("org.typelevel" %%% "cats-core" % "2.0.0")
   lazy val munit = Def.setting("org.scalameta" %%% "munit" % "1.0.0-M10")
   lazy val munitScalacheck = Def.setting("org.scalameta" %%% "munit-scalacheck" % "1.0.0-M10")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,9 @@ object Dependencies {
   lazy val cats = Def.setting("org.typelevel" %%% "cats-core" % "2.12.0")
   lazy val cats211 = Def.setting("org.typelevel" %%% "cats-core" % "2.0.0")
   lazy val munit = Def.setting("org.scalameta" %%% "munit" % "1.0.0")
+  lazy val munit211 = Def.setting("org.scalameta" %%% "munit" % "1.0.0-M10")
   lazy val munitScalacheck = Def.setting("org.scalameta" %%% "munit-scalacheck" % "1.0.0")
+  lazy val munitScalacheck211 = Def.setting("org.scalameta" %%% "munit-scalacheck" % "1.0.0-M10")
   lazy val fastParse = "com.lihaoyi" %% "fastparse" % "3.1.1"
   lazy val parsley = "org.http4s" %% "parsley" % "1.5.0-M3"
   lazy val jawnAst = Def.setting("org.typelevel" %% "jawn-ast" % "1.6.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.17")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.4")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.16.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.1.0")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.7")


### PR DESCRIPTION
This PR adds support for Scala Native 0.5
In doing so it updates:
- scala to 2.13.14
- cats to 2.12.0
- scala-native to 0.5.4
- munit to 1.0.0

All of those changes may not have been strictly necessary, but it's what came naturally.

In particular, I'd love to have eyes on the [tlVersionIntroduced changes for Scala Native 0.5](https://github.com/typelevel/cats-parse/commit/05016138e40d8e5c759ecfea99c7fcd36e7797eb) 

resolves https://github.com/typelevel/cats-parse/pull/593
resolves https://github.com/typelevel/cats-parse/pull/589
resolves https://github.com/typelevel/cats-parse/pull/584
resolves https://github.com/typelevel/cats-parse/pull/574